### PR TITLE
[feat] #13 채팅 환경설정 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
+
+	// WebSocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/common/config/WebSocketConfig.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/common/config/WebSocketConfig.java
@@ -1,0 +1,27 @@
+package com.lovesoongalarm.lovesoongalarm.common.config;
+
+import com.lovesoongalarm.lovesoongalarm.domain.chat.handler.WebSocketChatHandler;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.interceptor.WebSocketJWTAuthInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    private final WebSocketChatHandler webSocketChatHandler;
+    private final WebSocketJWTAuthInterceptor webSocketJWTAuthInterceptor;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry
+                .addHandler(webSocketChatHandler, "/ws/chats")
+                .addInterceptors(webSocketJWTAuthInterceptor)
+                .setAllowedOrigins("http://localhost:5173") // TODO 프론트 배포 주소 추가하기
+                .withSockJS();
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/common/config/WebSocketConfig.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/common/config/WebSocketConfig.java
@@ -21,7 +21,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
         registry
                 .addHandler(webSocketChatHandler, "/ws/chats")
                 .addInterceptors(webSocketJWTAuthInterceptor)
-                .setAllowedOrigins("http://localhost:5173") // TODO 프론트 배포 주소 추가하기
+                .setAllowedOrigins("http://localhost:5173", "https://love-soong-alarm-web.vercel.app/")
                 .withSockJS();
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/application/WebSocketMessageDTO.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/application/WebSocketMessageDTO.java
@@ -1,0 +1,19 @@
+package com.lovesoongalarm.lovesoongalarm.domain.chat.application;
+
+import com.lovesoongalarm.lovesoongalarm.domain.chat.persistence.type.EWebSocketMessageType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+public class WebSocketMessageDTO {
+
+    @Builder
+    public record ConnectionInfo(
+            EWebSocketMessageType type,
+            Long userId,
+            String userNickname,
+            LocalDateTime timestamp,
+            String message
+    ) {
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/business/ChatService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/business/ChatService.java
@@ -21,4 +21,8 @@ public class ChatService {
         messageService.sendConnectionSuccessMessage(userId, userNickname, session);
         log.info("사용자 연결 완료 - userId: {}, sessionId: {}", userId, session.getId());
     }
+
+    public void removeSession(Long userId) {
+        sessionService.removeSession(userId);
+    }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/business/ChatService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/business/ChatService.java
@@ -15,10 +15,10 @@ public class ChatService {
     private final ChatSessionService sessionService;
     private final ChatMessageService messageService;
 
-    public void registerSession(Long userId, WebSocketSession session) {
+    public void registerSession(Long userId, String userNickname, WebSocketSession session) {
         log.info("사용자 연결 시작 - userId: {}, sessionId: {}", userId, session.getId());
         sessionService.addSession(userId, session);
-        messageService.sendConnectionSuccessMessage(userId, session);
+        messageService.sendConnectionSuccessMessage(userId, userNickname, session);
         log.info("사용자 연결 완료 - userId: {}, sessionId: {}", userId, session.getId());
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/business/ChatService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/business/ChatService.java
@@ -1,0 +1,24 @@
+package com.lovesoongalarm.lovesoongalarm.domain.chat.business;
+
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.message.business.ChatMessageService;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.session.business.ChatSessionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.WebSocketSession;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final ChatSessionService sessionService;
+    private final ChatMessageService messageService;
+
+    public void registerSession(Long userId, WebSocketSession session) {
+        log.info("사용자 연결 시작 - userId: {}, sessionId: {}", userId, session.getId());
+        sessionService.addSession(userId, session);
+        messageService.sendConnectionSuccessMessage(userId, session);
+        log.info("사용자 연결 완료 - userId: {}, sessionId: {}", userId, session.getId());
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/handler/WebSocketChatHandler.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/handler/WebSocketChatHandler.java
@@ -13,11 +13,14 @@ public class WebSocketChatHandler extends TextWebSocketHandler {
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
-
+        log.info("웹소켓 연결 성공");
     }
 
     @Override
     public void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        log.info("메시지 수신");
+        log.info("메시지: {}", message.getPayload());
+
 
     }
 
@@ -28,6 +31,6 @@ public class WebSocketChatHandler extends TextWebSocketHandler {
 
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
-
+        log.info("웹소켓 연결 종료");
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/handler/WebSocketChatHandler.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/handler/WebSocketChatHandler.java
@@ -1,5 +1,7 @@
 package com.lovesoongalarm.lovesoongalarm.domain.chat.handler;
 
+import com.lovesoongalarm.lovesoongalarm.domain.chat.business.ChatService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
@@ -9,11 +11,22 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class WebSocketChatHandler extends TextWebSocketHandler {
+
+    private final ChatService chatService;
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
         log.info("웹소켓 연결 성공");
+
+        try {
+            Long userId = (Long) session.getAttributes().get("userId");
+            chatService.registerSession(userId, session);
+        } catch (Exception e) {
+            log.error("WebSocket 연결 처리 중 오류 발생", e);
+            session.close();
+        }
     }
 
     @Override

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/handler/WebSocketChatHandler.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/handler/WebSocketChatHandler.java
@@ -1,0 +1,33 @@
+package com.lovesoongalarm.lovesoongalarm.domain.chat.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+@Component
+@Slf4j
+public class WebSocketChatHandler extends TextWebSocketHandler {
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+
+    }
+
+    @Override
+    public void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+
+    }
+
+    @Override
+    public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
+
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/handler/WebSocketChatHandler.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/handler/WebSocketChatHandler.java
@@ -48,5 +48,12 @@ public class WebSocketChatHandler extends TextWebSocketHandler {
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
         log.info("웹소켓 연결 종료");
+
+        Long userId = (Long) session.getAttributes().get("userId");
+        log.info("세션 ID: {}, 사용자 ID: {}, 종료 상태: {}", session.getId(), userId, status);
+
+        if (userId != null) {
+            chatService.removeSession(userId);
+        }
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/handler/WebSocketChatHandler.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/handler/WebSocketChatHandler.java
@@ -1,6 +1,7 @@
 package com.lovesoongalarm.lovesoongalarm.domain.chat.handler;
 
 import com.lovesoongalarm.lovesoongalarm.domain.chat.business.ChatService;
+import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.business.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -15,6 +16,7 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 public class WebSocketChatHandler extends TextWebSocketHandler {
 
     private final ChatService chatService;
+    private final UserQueryService userQueryService;
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
@@ -22,7 +24,8 @@ public class WebSocketChatHandler extends TextWebSocketHandler {
 
         try {
             Long userId = (Long) session.getAttributes().get("userId");
-            chatService.registerSession(userId, session);
+            String userNickname = userQueryService.getUserNickname(userId);
+            chatService.registerSession(userId, userNickname, session);
         } catch (Exception e) {
             log.error("WebSocket 연결 처리 중 오류 발생", e);
             session.close();

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/interceptor/WebSocketJWTAuthInterceptor.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/interceptor/WebSocketJWTAuthInterceptor.java
@@ -15,6 +15,8 @@ public class WebSocketJWTAuthInterceptor implements HandshakeInterceptor {
     @Override
     public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
                                    WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        log.info("JWT 기반 WebSocket 인증 시작");
+
         return false;
     }
 

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/interceptor/WebSocketJWTAuthInterceptor.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/interceptor/WebSocketJWTAuthInterceptor.java
@@ -1,0 +1,26 @@
+package com.lovesoongalarm.lovesoongalarm.domain.chat.interceptor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+@Component
+@Slf4j
+public class WebSocketJWTAuthInterceptor implements HandshakeInterceptor {
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                                   WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        return false;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                               WebSocketHandler wsHandler, Exception exception) {
+
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/interceptor/WebSocketJWTAuthInterceptor.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/interceptor/WebSocketJWTAuthInterceptor.java
@@ -17,12 +17,48 @@ public class WebSocketJWTAuthInterceptor implements HandshakeInterceptor {
                                    WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
         log.info("JWT 기반 WebSocket 인증 시작");
 
-        return false;
+        try {
+            String token = extractTokenFromQuery(request);
+
+            if (token == null) {
+                log.error("JWT 토큰이 없습니다");
+                return false;
+            }
+
+            // TODO - JWT 인증 로직 추가 및 JWT에서 userId 가져오기
+
+            Long userId = Long.parseLong(token);
+            attributes.put("userId", userId);
+
+            log.info("JWT 인증 성공 - userId: {}", userId);
+            return true;
+        } catch (Exception e) {
+            log.error("JWT 인증 처리 중 오류 발생", e);
+            return false;
+        }
     }
 
     @Override
     public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
                                WebSocketHandler wsHandler, Exception exception) {
+        if (exception != null) {
+            log.error("WebSocket handshake 중 오류 발생", exception);
+        }
+    }
 
+    private String extractTokenFromQuery(ServerHttpRequest request) {
+        String query = request.getURI().getQuery();
+
+        if (query == null) {
+            return null;
+        }
+
+        for (String param : query.split("&")) {
+            if (param.startsWith("token=")) {
+                return param.substring(6);
+            }
+        }
+
+        return null;
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/persistence/type/EWebSocketMessageType.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/persistence/type/EWebSocketMessageType.java
@@ -1,0 +1,12 @@
+package com.lovesoongalarm.lovesoongalarm.domain.chat.persistence.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EWebSocketMessageType {
+    CONNECTION_SUCCESS("연결 완료");
+
+    private final String value;
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/message/business/ChatMessageService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/message/business/ChatMessageService.java
@@ -1,0 +1,33 @@
+package com.lovesoongalarm.lovesoongalarm.domain.chat.sub.message.business;
+
+import com.lovesoongalarm.lovesoongalarm.domain.chat.application.WebSocketMessageDTO;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.persistence.type.EWebSocketMessageType;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.message.implement.MessageSender;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.time.LocalDateTime;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+    private final MessageSender messageSender;
+
+    @Transactional
+    public void sendConnectionSuccessMessage(Long userId, String userNickname, WebSocketSession session) {
+        WebSocketMessageDTO.ConnectionInfo connectionInfo = WebSocketMessageDTO.ConnectionInfo.builder()
+                .type(EWebSocketMessageType.CONNECTION_SUCCESS)
+                .userId(userId)
+                .userNickname(userNickname)
+                .timestamp(LocalDateTime.now())
+                .message("WebSocket 연결이 성공했습니다.")
+                .build();
+
+        messageSender.sendMessage(session, connectionInfo);
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/message/implement/MessageSender.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/message/implement/MessageSender.java
@@ -1,0 +1,27 @@
+package com.lovesoongalarm.lovesoongalarm.domain.chat.sub.message.implement;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MessageSender {
+
+    private final ObjectMapper objectMapper;
+
+    public void sendMessage(WebSocketSession session, Object message) {
+        try {
+            String messageJson = objectMapper.writeValueAsString(message);
+            synchronized (session) {
+                session.sendMessage(new TextMessage(messageJson));
+            }
+        } catch (Exception e) {
+            log.error("메시지 전송 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/session/business/ChatSessionService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/session/business/ChatSessionService.java
@@ -1,0 +1,24 @@
+package com.lovesoongalarm.lovesoongalarm.domain.chat.sub.session.business;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ChatSessionService {
+
+    private final Map<Long, WebSocketSession> memberSessions = new ConcurrentHashMap<>();
+
+    @Transactional
+    public void addSession(Long userId, WebSocketSession session) {
+        memberSessions.put(userId, session);
+        log.info("로컬 세션에 user 추가 완료 - userId: {}, sessionId: {}", userId, session.getId());
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/session/business/ChatSessionService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/session/business/ChatSessionService.java
@@ -14,11 +14,17 @@ import java.util.concurrent.ConcurrentHashMap;
 @RequiredArgsConstructor
 public class ChatSessionService {
 
-    private final Map<Long, WebSocketSession> memberSessions = new ConcurrentHashMap<>();
+    private final Map<Long, WebSocketSession> userSessions = new ConcurrentHashMap<>();
 
     @Transactional
     public void addSession(Long userId, WebSocketSession session) {
-        memberSessions.put(userId, session);
+        userSessions.put(userId, session);
         log.info("로컬 세션에 user 추가 완료 - userId: {}, sessionId: {}", userId, session.getId());
+    }
+
+    @Transactional
+    public void removeSession(Long userId) {
+        userSessions.remove(userId);
+        log.info("로컬 세션에서 user 제거 완료 - userId: {}", userId);
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/business/UserQueryService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/business/UserQueryService.java
@@ -1,0 +1,20 @@
+package com.lovesoongalarm.lovesoongalarm.domain.user.persistence.business;
+
+import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.User;
+import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.implement.UserRetriever;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserQueryService {
+
+    private final UserRetriever userRetriever;
+
+    public String getUserNickname(Long userId) {
+        User user = userRetriever.findByUserId(userId);
+        return user.getNickname();
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/exception/UserErrorCode.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/exception/UserErrorCode.java
@@ -1,0 +1,23 @@
+package com.lovesoongalarm.lovesoongalarm.domain.user.persistence.exception;
+
+import com.lovesoongalarm.lovesoongalarm.common.code.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/implement/UserRetriever.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/implement/UserRetriever.java
@@ -1,0 +1,20 @@
+package com.lovesoongalarm.lovesoongalarm.domain.user.persistence.implement;
+
+import com.lovesoongalarm.lovesoongalarm.common.exception.CustomException;
+import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.User;
+import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.exception.UserErrorCode;
+import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserRetriever {
+
+    private final UserRepository userRepository;
+
+    public User findByUserId(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## 관련 이슈 🛠
<!-- 관련 이슈 번호를 적어주세요. -->
- closes #13 

## 작업 내용 ✏️
<!-- 작업 내용을 간단히 작성해주세요. -->
- [ ] `WebSocketConfig`에서 웹소켓 연결 경로 및 허용하는 경로를 지정합니다.
- [ ] `WebSocketInterceptor`에서는 핸드셰이크 과정 중에 인증을 진행합니다. 현재는 JWT 인증이 구현되어 있지 않으므로 단순히 `userId`를 받아오도록 구현했습니다.
- [ ] `WebSocketHandler`에서는 웹소켓의 전반적인 처리를 하는 클래스입니다. 웹소켓 연결 시 `ChatService`->`SessionService`에서 `userSessions`에 웹소켓을 연결한 유저의 세션값을 넣고, `ChatService`->`ChatMessageService`->`messageSender`를 통해 연결 완료 메시지를 응답으로 반환합니다.
- [ ] 웹소켓 연결을 종료하면 `userSessions`에서 `user` 세션을 제거합니다.
- [ ] 현재 웹소켓 로직 처리 중 에러 메시지를 반환하는 로직은 아직 미구현상태입니다.
- [ ] 포스트맨으로 테스트하고 싶으실경우 `HTTP` 대신 `WebSocket`을 선택한 뒤, `ws://localhost:8080/ws/chats/websocket?token=1` 경로로 연결을 시도하시면 연결 가능합니다.

<img width="1715" height="139" alt="image" src="https://github.com/user-attachments/assets/56445209-9e8b-492a-90fd-c87571facdce" />
<img width="1676" height="507" alt="image" src="https://github.com/user-attachments/assets/bb7c6643-ae83-4c67-9ab3-393d0986e9e4" />


## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점 등을 필요하다면 작성해주세요. -->
