### PR TITLE
Feat #81 웹소켓 연결 시 내 채팅방 목록 구독로직 구현

### DIFF
--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/common/constant/RedisKey.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/common/constant/RedisKey.java
@@ -7,4 +7,6 @@ public class RedisKey {
     public static final String LAST_SEEN_INDEX_KEY = "lastseen:index";
     public static final String USER_INTEREST_KEY = "user:interests:";
     public static final String USER_GENDER_KEY = "user:gender";
+    public static final String CHAT_ROOM_SUBSCRIBERS_KEY = "chatroom:subscribers:";
+    public static final String USER_CHAT_SUBSCRIBERS_KEY = "user:chat:subscribers:";
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/application/dto/WebSocketMessageDTO.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/application/dto/WebSocketMessageDTO.java
@@ -53,6 +53,13 @@ public class WebSocketMessageDTO {
     }
 
     @Builder
+    public record UnreadBadgeUpdate(
+            EWebSocketMessageType type,
+            int totalUnreadCount
+    ) {
+    }
+
+    @Builder
     public record ErrorResponse(
             EWebSocketMessageType type,
             String errorCode,

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/application/dto/WebSocketMessageDTO.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/application/dto/WebSocketMessageDTO.java
@@ -63,13 +63,10 @@ public class WebSocketMessageDTO {
     public record ChatListUpdate(
             EWebSocketMessageType type,
             Long chatRoomId,
-            String partnerNickname,
-            String partnerEmoji,
             String lastMessageContent,
             LocalDateTime timestamp,
             boolean isMyMessage,
-            boolean isRead,
-            int totalUnreadCount
+            boolean isRead
     ) {
     }
 

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/application/dto/WebSocketMessageDTO.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/application/dto/WebSocketMessageDTO.java
@@ -60,6 +60,20 @@ public class WebSocketMessageDTO {
     }
 
     @Builder
+    public record ChatListUpdate(
+            EWebSocketMessageType type,
+            Long chatRoomId,
+            String partnerNickname,
+            String partnerEmoji,
+            String lastMessageContent,
+            LocalDateTime timestamp,
+            boolean isMyMessage,
+            boolean isRead,
+            int totalUnreadCount
+    ) {
+    }
+
+    @Builder
     public record ErrorResponse(
             EWebSocketMessageType type,
             String errorCode,

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/business/ChatService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/business/ChatService.java
@@ -60,4 +60,10 @@ public class ChatService {
         subscriptionService.subscribeToUserChatUpdates(userId);
         log.info("사용자 채팅방 구독 완료 - userId: {}, sessionId: {}", userId, session.getId());
     }
+
+    public void unsubscribeFromUserChatUpdates(Long userId, WebSocketSession session) {
+        log.info("사용자 채팅방 구독 해제 시작 - userId: {}, sessionId: {}", userId, session.getId());
+        subscriptionService.unsubscribeFromUserChatUpdates(userId);
+        log.info("사용자 채팅방 구독 해제 완료 - userId: {}, sessionId: {}", userId, session.getId());
+    }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/business/ChatService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/business/ChatService.java
@@ -5,6 +5,7 @@ import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.persistence.entity
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.business.MessageService;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.business.WebSocketMessageService;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.session.business.ChatSessionService;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.subscription.business.SubscriptionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ public class ChatService {
     private final ChatSessionService sessionService;
     private final WebSocketMessageService webSocketMessageService;
     private final ChatRoomService chatRoomService;
+    private final SubscriptionService subscriptionService;
     private final MessageService messageService;
 
     public void registerSession(Long userId, String userNickname, WebSocketSession session) {
@@ -51,5 +53,11 @@ public class ChatService {
         ChatRoom chatRoom = chatRoomService.getChatRoomOrElseThrow(chatRoomId);
         messageService.sendMessage(chatRoom, content, userId);
         log.info("메시지 송신 완료 - userId: {}, chatRoomId: {}", userId, chatRoomId);
+    }
+
+    public void subscribeToUserChatUpdates(Long userId, WebSocketSession session) {
+        log.info("사용자 채팅방 구독 시작 - userId: {}, sessionId: {}", userId, session.getId());
+        subscriptionService.subscribeToUserChatUpdates(userId);
+        log.info("사용자 채팅방 구독 완료 - userId: {}, sessionId: {}", userId, session.getId());
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/business/ChatService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/business/ChatService.java
@@ -57,7 +57,7 @@ public class ChatService {
 
     public void subscribeToUserChatUpdates(Long userId, WebSocketSession session) {
         log.info("사용자 채팅방 구독 시작 - userId: {}, sessionId: {}", userId, session.getId());
-        subscriptionService.subscribeToUserChatUpdates(userId);
+        subscriptionService.subscribeToUserChatUpdates(session, userId);
         log.info("사용자 채팅방 구독 완료 - userId: {}, sessionId: {}", userId, session.getId());
     }
 

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/handler/WebSocketChatHandler.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/handler/WebSocketChatHandler.java
@@ -92,6 +92,7 @@ public class WebSocketChatHandler extends TextWebSocketHandler {
 
         if (userId != null) {
             chatService.removeSession(userId);
+            chatService.subscribeToUserChatUpdates(userId, session);
         }
     }
 

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/handler/WebSocketChatHandler.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/handler/WebSocketChatHandler.java
@@ -33,6 +33,7 @@ public class WebSocketChatHandler extends TextWebSocketHandler {
             Long userId = (Long) session.getAttributes().get("userId");
             String userNickname = userQueryService.getUserNickname(userId);
             chatService.registerSession(userId, userNickname, session);
+            chatService.subscribeToUserChatUpdates(userId, session);
         } catch (Exception e) {
             log.error("WebSocket 연결 처리 중 오류 발생", e);
             session.close();

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/handler/WebSocketChatHandler.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/handler/WebSocketChatHandler.java
@@ -92,7 +92,7 @@ public class WebSocketChatHandler extends TextWebSocketHandler {
 
         if (userId != null) {
             chatService.removeSession(userId);
-            chatService.subscribeToUserChatUpdates(userId, session);
+            chatService.unsubscribeFromUserChatUpdates(userId, session);
         }
     }
 

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/persistence/type/EWebSocketMessageType.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/persistence/type/EWebSocketMessageType.java
@@ -12,6 +12,7 @@ public enum EWebSocketMessageType {
     MESSAGE_SEND("메시지 송신"),
     MESSAGE_READ("메시지 읽음"),
     CHAT_MESSAGE("채팅 메시지"),
+    UNREAD_BADGE_UPDATE("안 읽은 메시지 배지 업데이트"),
     ERROR("에러");
 
     private final String value;

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/persistence/type/EWebSocketMessageType.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/persistence/type/EWebSocketMessageType.java
@@ -13,6 +13,7 @@ public enum EWebSocketMessageType {
     MESSAGE_READ("메시지 읽음"),
     CHAT_MESSAGE("채팅 메시지"),
     UNREAD_BADGE_UPDATE("안 읽은 메시지 배지 업데이트"),
+    CHAT_LIST_UPDATE("채팅방 목록 업데이트"),
     ERROR("에러");
 
     private final String value;

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/application/dto/UserChatUpdateDTO.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/application/dto/UserChatUpdateDTO.java
@@ -10,7 +10,6 @@ public record UserChatUpdateDTO(
         String lastMessageContent,
         LocalDateTime timestamp,
         boolean isMyMessage,
-        boolean isRead,
-        int totalUnreadCount
+        boolean isRead
 ) {
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/application/dto/UserChatUpdateDTO.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/application/dto/UserChatUpdateDTO.java
@@ -1,0 +1,16 @@
+package com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.application.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record UserChatUpdateDTO(
+        Long chatRoomId,
+        String lastMessageContent,
+        LocalDateTime timestamp,
+        boolean isMyMessage,
+        boolean isRead,
+        int totalUnreadCount
+) {
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/MessageNotificationService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/MessageNotificationService.java
@@ -90,17 +90,20 @@ public class MessageNotificationService {
         int receiverUnreadCount = unreadCountService.getTotalUnreadCount(receiverId);
         userChatSubscriptionService.publishUnreadBadgeUpdate(receiverId, receiverUnreadCount);
 
-        UserChatUpdateDTO receiverUpdate = UserChatUpdateDTO.builder()
-                .chatRoomId(chatRoomId)
-                .lastMessageContent(message.getContent())
-                .timestamp(message.getCreatedAt())
-                .isMyMessage(false)
-                .isRead(message.isRead())
-                .build();
+        boolean isPartnerSubscribedToRoom = redisSubscriber.isUserSubscribed(chatRoomId, receiverId);
+        if (!isPartnerSubscribedToRoom) {
+            UserChatUpdateDTO receiverUpdate = UserChatUpdateDTO.builder()
+                    .chatRoomId(chatRoomId)
+                    .lastMessageContent(message.getContent())
+                    .timestamp(message.getCreatedAt())
+                    .isMyMessage(false)
+                    .isRead(message.isRead())
+                    .build();
 
-        userChatSubscriptionService.publishUserChatUpdate(receiverId, receiverUpdate);
+            userChatSubscriptionService.publishUserChatUpdate(receiverId, receiverUpdate);
 
-        log.debug("메시지 수신자 채팅방 목록 업데이트 - receiverId: {}, chatRoomId: {}, unreadCount: {}",
-                receiverId, chatRoomId, receiverUnreadCount);
+            log.debug("메시지 수신자 채팅방 목록 업데이트 - receiverId: {}, chatRoomId: {}, unreadCount: {}",
+                    receiverId, chatRoomId, receiverUnreadCount);
+        }
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/MessageNotificationService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/MessageNotificationService.java
@@ -3,7 +3,6 @@ package com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.busin
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.application.dto.UserChatUpdateDTO;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.persistence.entity.Message;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.session.business.ChatSessionService;
-import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.subscription.business.SubscriptionService;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.subscription.implement.RedisSubscriber;
 import com.lovesoongalarm.lovesoongalarm.domain.user.business.UserService;
 import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.User;
@@ -95,7 +94,6 @@ public class MessageNotificationService {
                 .timestamp(message.getCreatedAt())
                 .isMyMessage(false)
                 .isRead(message.isRead())
-                .totalUnreadCount(receiverUnreadCount)
                 .build();
 
         publishUserChatUpdate(receiverId, receiverUpdate);

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/MessageNotificationService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/MessageNotificationService.java
@@ -2,6 +2,7 @@ package com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.busin
 
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.persistence.entity.Message;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.session.business.ChatSessionService;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.subscription.business.SubscriptionService;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.subscription.implement.RedisSubscriber;
 import com.lovesoongalarm.lovesoongalarm.domain.user.business.UserService;
 import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.User;
@@ -21,6 +22,8 @@ public class MessageNotificationService {
     private final UserService userService;
     private final MessageReadService messageReadService;
     private final WebSocketMessageService webSocketMessageService;
+    private final SubscriptionService subscriptionService;
+    private final UnreadCountService unreadCountService;
 
     public void notifyMessage(Long chatRoomId, Message message, Long senderId) {
         log.info("1:1 채팅 메시지 알림 전송 시작 - chatRoomId: {}, messageId: {}, senderId: {}",
@@ -48,6 +51,22 @@ public class MessageNotificationService {
         }
     }
 
+    public void handleChatListUpdate(Long chatRoomId, Message message, Long senderId) {
+        try {
+            User partner = userService.getPartnerUser(chatRoomId, senderId);
+            Long partnerId = partner.getId();
+
+            publishReceiverChatListUpdate(partnerId, chatRoomId, message);
+
+            log.info("채팅방 목록 양방향 업데이트 완료 - chatRoomId: {}, senderId: {}, partnerId: {}",
+                    chatRoomId, senderId, partnerId);
+
+        } catch (Exception e) {
+            log.error("채팅방 목록 업데이트 실패 - chatRoomId: {}, senderId: {}",
+                    chatRoomId, senderId, e);
+        }
+    }
+
     private void sendMessageToUser(Long chatRoomId, Long senderId, Message message, boolean isSentByMe) {
         try {
             WebSocketSession session = chatSessionService.getSession(senderId);
@@ -63,6 +82,34 @@ public class MessageNotificationService {
         } catch (Exception e) {
             log.error("사용자에게 메시지 전송 실패 - senderId: {}, messageId: {}",
                     senderId, message.getId(), e);
+        }
+    }
+
+    private void publishReceiverChatListUpdate(Long receiverId, Long chatRoomId, Message message) {
+        int receiverUnreadCount = unreadCountService.getTotalUnreadCount(receiverId);
+        publishUnreadBadgeUpdate(receiverId, receiverUnreadCount);
+
+        log.debug("메시지 수신자 채팅방 목록 업데이트 - receiverId: {}, chatRoomId: {}, unreadCount: {}",
+                receiverId, chatRoomId, receiverUnreadCount);
+    }
+
+    private void publishUnreadBadgeUpdate(Long userId, int totalUnreadCount) {
+        try {
+            if (!redisSubscriber.isUserSubscribed(userId)) {
+                return;
+            }
+
+            WebSocketSession session = chatSessionService.getSession(userId);
+            if (session == null || !session.isOpen()) {
+                log.debug("사용자 세션이 없거나 닫혀있음 - userId: {}", userId);
+                return;
+            }
+
+            webSocketMessageService.sendUnreadBadgeUpdate(session, totalUnreadCount);
+            log.info("안 읽은 메시지 배지 업데이트 전송 완료 - userId: {}, count: {}", userId, totalUnreadCount);
+
+        } catch (Exception e) {
+            log.error("안 읽은 메시지 배지 업데이트 발행 실패 - userId: {}", userId, e);
         }
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/MessageReadService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/MessageReadService.java
@@ -5,6 +5,7 @@ import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.implem
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.implement.MessageUpdater;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.persistence.entity.Message;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.session.business.ChatSessionService;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.subscription.business.UserChatSubscriptionService;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.subscription.implement.RedisSubscriber;
 import com.lovesoongalarm.lovesoongalarm.domain.user.business.UserService;
 import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.User;
@@ -29,7 +30,7 @@ public class MessageReadService {
     private final ChatSessionService chatSessionService;
     private final WebSocketMessageService webSocketMessageService;
     private final UnreadCountService unreadCountService;
-    private final MessageNotificationService messageNotificationService;
+    private final UserChatSubscriptionService userChatSubscriptionService;
 
     public void processAutoReadOnSubscribe(Long chatRoomId, Long userId) {
         log.info("채팅방 구독 시 자동읽음 처리 시작 - chatRoomId: {}, userId: {}", chatRoomId, userId);
@@ -96,7 +97,7 @@ public class MessageReadService {
             notifyPartnerOfReadStatus(chatRoomId, partner.getId(), message);
 
             int updatedUnreadCount = unreadCountService.getTotalUnreadCount(userId);
-            messageNotificationService.publishUnreadBadgeUpdate(userId, updatedUnreadCount);
+            userChatSubscriptionService.publishUnreadBadgeUpdate(userId, updatedUnreadCount);
 
             log.info("읽음 처리 시 채팅방 목록 업데이트 완료 - userId: {}, chatRoomId: {}, readCount: {}, newUnreadCount: {}",
                     userId, chatRoomId, readCount, updatedUnreadCount);
@@ -119,7 +120,7 @@ public class MessageReadService {
                         .isRead(lastMessage.isRead())
                         .build();
 
-                messageNotificationService.publishUserChatUpdate(partnerId, partnerUpdate);
+                userChatSubscriptionService.publishUserChatUpdate(partnerId, partnerUpdate);
                 log.debug("상대방에게 읽음 상태 업데이트 알림 전송 - partnerId: {}, chatRoomId: {}", partnerId, chatRoomId);
             }
 

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/UnreadCountService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/UnreadCountService.java
@@ -1,0 +1,27 @@
+package com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.business;
+
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.implement.MessageRetriever;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UnreadCountService {
+    
+    private final MessageRetriever messageRetriever;
+
+    public int getTotalUnreadCount(Long userId) {
+        try {
+            int count = messageRetriever.countUnreadMessagesForUser(userId);
+            log.info("사용자 전체 안 읽은 메시지 수 조회 - userId: {}, count: {}", userId, count);
+            return count;
+        } catch (Exception e) {
+            log.error("안 읽은 메시지 수 조회 실패 - userId: {}", userId, e);
+            return 0;
+        }
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/WebSocketMessageService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/WebSocketMessageService.java
@@ -88,4 +88,13 @@ public class WebSocketMessageService {
 
         messageSender.sendMessage(session, chatMessage);
     }
+
+    public void sendUnreadBadgeUpdate(WebSocketSession session, int totalUnreadCount) {
+        WebSocketMessageDTO.UnreadBadgeUpdate unreadBadgeUpdate = WebSocketMessageDTO.UnreadBadgeUpdate.builder()
+                .type(EWebSocketMessageType.UNREAD_BADGE_UPDATE)
+                .totalUnreadCount(totalUnreadCount)
+                .build();
+
+        messageSender.sendMessage(session, unreadBadgeUpdate);
+    }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/WebSocketMessageService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/WebSocketMessageService.java
@@ -2,6 +2,7 @@ package com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.busin
 
 import com.lovesoongalarm.lovesoongalarm.domain.chat.application.dto.WebSocketMessageDTO;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.persistence.type.EWebSocketMessageType;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.application.dto.UserChatUpdateDTO;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.implement.MessageSender;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.persistence.entity.Message;
 import lombok.RequiredArgsConstructor;
@@ -96,5 +97,19 @@ public class WebSocketMessageService {
                 .build();
 
         messageSender.sendMessage(session, unreadBadgeUpdate);
+    }
+
+    public void sendChatListUpdate(WebSocketSession session, UserChatUpdateDTO updateEvent) {
+        WebSocketMessageDTO.ChatListUpdate chatListUpdate = WebSocketMessageDTO.ChatListUpdate.builder()
+                .type(EWebSocketMessageType.CHAT_LIST_UPDATE)
+                .chatRoomId(updateEvent.chatRoomId())
+                .lastMessageContent(updateEvent.lastMessageContent())
+                .timestamp(updateEvent.timestamp())
+                .isMyMessage(updateEvent.isMyMessage())
+                .isRead(updateEvent.isRead())
+                .totalUnreadCount(updateEvent.totalUnreadCount())
+                .build();
+
+        messageSender.sendMessage(session, chatListUpdate);
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/WebSocketMessageService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/WebSocketMessageService.java
@@ -107,7 +107,6 @@ public class WebSocketMessageService {
                 .timestamp(updateEvent.timestamp())
                 .isMyMessage(updateEvent.isMyMessage())
                 .isRead(updateEvent.isRead())
-                .totalUnreadCount(updateEvent.totalUnreadCount())
                 .build();
 
         messageSender.sendMessage(session, chatListUpdate);

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/event/listener/MessageEventListener.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/event/listener/MessageEventListener.java
@@ -27,6 +27,12 @@ public class MessageEventListener {
                     event.senderId()
             );
 
+            messageNotificationService.handleChatListUpdate(
+                    event.chatRoomId(),
+                    event.message(),
+                    event.senderId()
+            );
+
             log.info("웹소켓 메시지 전송 완료 - messageId: {}", event.message().getId());
         } catch (Exception e) {
             log.error("웹소켓 메시지 전송 실패 - chatRoomId: {}, messageId: {}",

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/implement/MessageRetriever.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/implement/MessageRetriever.java
@@ -34,8 +34,7 @@ public class MessageRetriever {
         return messageRepository.findPreviousMessagesByChatRoomIdAndLastMessageId(chatRoomId, lastMessageId, pageable);
     }
 
-    public Long getLatestMessageId(Long chatRoomId) {
-        return messageRepository.findLatestMessageIdByChatRoomId(chatRoomId)
-                .orElse(null);
+    public int countUnreadMessagesForUser(Long userId) {
+        return messageRepository.countUnreadMessagesForUser(userId);
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/business/SubscriptionService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/business/SubscriptionService.java
@@ -33,4 +33,8 @@ public class SubscriptionService {
     public void subscribeToUserChatUpdates(Long userId){
         redisSubscriber.subscribeToUserChatUpdates(userId);
     }
+
+    public void unsubscribeFromUserChatUpdates(Long userId){
+        redisSubscriber.unsubscribeFromUserChatUpdates(userId);
+    }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/business/SubscriptionService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/business/SubscriptionService.java
@@ -32,10 +32,11 @@ public class SubscriptionService {
         webSocketMessageService.sendUnsubscribeSuccessMessage(session, chatRoomId);
     }
 
-    public void subscribeToUserChatUpdates(Long userId){
+    public void subscribeToUserChatUpdates(WebSocketSession session, Long userId){
         redisSubscriber.subscribeToUserChatUpdates(userId);
 
         int totalUnreadCount = unreadCountService.getTotalUnreadCount(userId);
+        webSocketMessageService.sendUnreadBadgeUpdate(session, totalUnreadCount);
     }
 
     public void unsubscribeFromUserChatUpdates(Long userId){

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/business/SubscriptionService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/business/SubscriptionService.java
@@ -1,6 +1,7 @@
 package com.lovesoongalarm.lovesoongalarm.domain.chat.sub.subscription.business;
 
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.business.MessageReadService;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.business.UnreadCountService;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.business.WebSocketMessageService;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.subscription.implement.RedisSubscriber;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ public class SubscriptionService {
     private final RedisSubscriber redisSubscriber;
     private final MessageReadService messageReadService;
     private final WebSocketMessageService webSocketMessageService;
+    private final UnreadCountService unreadCountService;
 
     @Transactional
     public void subscribeToChatRoom(WebSocketSession session, Long chatRoomId, Long userId) {
@@ -32,6 +34,8 @@ public class SubscriptionService {
 
     public void subscribeToUserChatUpdates(Long userId){
         redisSubscriber.subscribeToUserChatUpdates(userId);
+
+        int totalUnreadCount = unreadCountService.getTotalUnreadCount(userId);
     }
 
     public void unsubscribeFromUserChatUpdates(Long userId){

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/business/SubscriptionService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/business/SubscriptionService.java
@@ -29,4 +29,8 @@ public class SubscriptionService {
         redisSubscriber.removeSubscriber(chatRoomId, userId);
         webSocketMessageService.sendUnsubscribeSuccessMessage(session, chatRoomId);
     }
+
+    public void subscribeToUserChatUpdates(Long userId){
+        redisSubscriber.subscribeToUserChatUpdates(userId);
+    }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/business/UserChatSubscriptionService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/business/UserChatSubscriptionService.java
@@ -1,0 +1,62 @@
+package com.lovesoongalarm.lovesoongalarm.domain.chat.sub.subscription.business;
+
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.application.dto.UserChatUpdateDTO;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.business.WebSocketMessageService;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.session.business.ChatSessionService;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.subscription.implement.RedisSubscriber;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.WebSocketSession;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class UserChatSubscriptionService {
+
+    private final RedisSubscriber redisSubscriber;
+
+    private final ChatSessionService chatSessionService;
+    private final WebSocketMessageService webSocketMessageService;
+
+    public void publishUnreadBadgeUpdate(Long userId, int totalUnreadCount) {
+        try {
+            if (!redisSubscriber.isUserSubscribed(userId)) {
+                return;
+            }
+
+            WebSocketSession session = chatSessionService.getSession(userId);
+            if (session == null || !session.isOpen()) {
+                log.debug("사용자 세션이 없거나 닫혀있음 - userId: {}", userId);
+                return;
+            }
+
+            webSocketMessageService.sendUnreadBadgeUpdate(session, totalUnreadCount);
+            log.info("안 읽은 메시지 배지 업데이트 전송 완료 - userId: {}, count: {}", userId, totalUnreadCount);
+
+        } catch (Exception e) {
+            log.error("안 읽은 메시지 배지 업데이트 발행 실패 - userId: {}", userId, e);
+        }
+    }
+
+    public void publishUserChatUpdate(Long userId, UserChatUpdateDTO updateEvent) {
+        try {
+            if (!redisSubscriber.isUserSubscribed(userId)) {
+                log.debug("구독하지 않은 사용자에게는 업데이트를 보내지 않음 - userId: {}", userId);
+                return;
+            }
+
+            WebSocketSession session = chatSessionService.getSession(userId);
+            if (session == null || !session.isOpen()) {
+                log.debug("사용자 세션이 없거나 닫혀있음 - userId: {}", userId);
+                return;
+            }
+
+            webSocketMessageService.sendChatListUpdate(session, updateEvent);
+            log.info("사용자 채팅 업데이트 전송 완료 - userId: {}, chatRoomId: {}", userId, updateEvent.chatRoomId());
+
+        } catch (Exception e) {
+            log.error("사용자 채팅 업데이트 발행 실패 - userId: {}", userId, e);
+        }
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/implement/RedisSubscriber.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/implement/RedisSubscriber.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 
 import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.CHAT_ROOM_SUBSCRIBERS_KEY;
+import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.USER_CHAT_SUBSCRIBERS_KEY;
 
 @Service
 @RequiredArgsConstructor
@@ -61,6 +62,19 @@ public class RedisSubscriber {
         } catch (Exception e) {
             log.error("Redis 구독 상태 체크 실패 - 채팅방: {}, 유저: {}", chatRoomId, userId, e);
             return false;
+        }
+    }
+
+    public void subscribeToUserChatUpdates(Long userId) {
+        try {
+            String subscribersKey = USER_CHAT_SUBSCRIBERS_KEY + userId;
+
+            stringRedisTemplate.opsForSet().add(subscribersKey, userId.toString());
+            stringRedisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
+
+            log.info("사용자 채팅 업데이트 구독 시작 - userId: {}", userId);
+        } catch (Exception e) {
+            log.error("사용자 채팅 업데이트 구독 실패 - userId: {}", userId, e);
         }
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/implement/RedisSubscriber.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/implement/RedisSubscriber.java
@@ -16,7 +16,7 @@ public class RedisSubscriber {
 
     private final StringRedisTemplate stringRedisTemplate;
 
-    private static final Duration SUBSCRIPTION_TTL = Duration.ofHours(2);
+    private static final Duration SUBSCRIPTION_TTL = Duration.ofHours(24);
 
     public void addSubscriber(Long chatRoomId, Long userId) {
         try {

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/implement/RedisSubscriber.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/implement/RedisSubscriber.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 
+import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.CHAT_ROOM_SUBSCRIBERS_KEY;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -14,13 +16,11 @@ public class RedisSubscriber {
 
     private final StringRedisTemplate stringRedisTemplate;
 
-    private static final String CHAT_ROOM_SUBSCRIBERS = "chatroom:subscribers:";
-
     private static final Duration SUBSCRIPTION_TTL = Duration.ofHours(2);
 
     public void addSubscriber(Long chatRoomId, Long userId) {
         try {
-            String subscribersKey = CHAT_ROOM_SUBSCRIBERS + chatRoomId;
+            String subscribersKey = CHAT_ROOM_SUBSCRIBERS_KEY + chatRoomId;
             stringRedisTemplate.opsForSet().add(subscribersKey, userId.toString());
             stringRedisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
 
@@ -30,10 +30,10 @@ public class RedisSubscriber {
             log.error("Redis 구독 추가 실패 - 채팅방: {}, 유저: {}", chatRoomId, userId, e);
         }
     }
-    
+
     public void removeSubscriber(Long chatRoomId, Long userId) {
         try {
-            String subscribersKey = CHAT_ROOM_SUBSCRIBERS + chatRoomId;
+            String subscribersKey = CHAT_ROOM_SUBSCRIBERS_KEY + chatRoomId;
             stringRedisTemplate.opsForSet().remove(subscribersKey, userId.toString());
 
             Long remainingCount = stringRedisTemplate.opsForSet().size(subscribersKey);
@@ -53,7 +53,7 @@ public class RedisSubscriber {
 
     public boolean isUserSubscribed(Long chatRoomId, Long userId) {
         try {
-            String subscribersKey = CHAT_ROOM_SUBSCRIBERS + chatRoomId;
+            String subscribersKey = CHAT_ROOM_SUBSCRIBERS_KEY + chatRoomId;
             Boolean isMember = stringRedisTemplate.opsForSet().isMember(subscribersKey, userId.toString());
 
             boolean isSubscribed = Boolean.TRUE.equals(isMember);

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/implement/RedisSubscriber.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/implement/RedisSubscriber.java
@@ -77,4 +77,23 @@ public class RedisSubscriber {
             log.error("사용자 채팅 업데이트 구독 실패 - userId: {}", userId, e);
         }
     }
+
+    public void unsubscribeFromUserChatUpdates(Long userId) {
+        try {
+            String subscribersKey = USER_CHAT_SUBSCRIBERS_KEY + userId;
+            stringRedisTemplate.opsForSet().remove(subscribersKey, userId.toString());
+
+            Long remainingCount = stringRedisTemplate.opsForSet().size(subscribersKey);
+            if (remainingCount != null && remainingCount == 0) {
+                stringRedisTemplate.delete(subscribersKey);
+                log.debug("빈 구독 키 삭제 - userId: {}", userId);
+            } else {
+                stringRedisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
+            }
+
+            log.info("사용자 채팅 업데이트 구독 해제 - userId: {}", userId);
+        } catch (Exception e) {
+            log.error("사용자 채팅 업데이트 구독 해제 실패 - userId: {}", userId, e);
+        }
+    }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/implement/RedisSubscriber.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/subscription/implement/RedisSubscriber.java
@@ -96,4 +96,18 @@ public class RedisSubscriber {
             log.error("사용자 채팅 업데이트 구독 해제 실패 - userId: {}", userId, e);
         }
     }
+
+    public boolean isUserSubscribed(Long userId) {
+        try {
+            String subscribersKey = USER_CHAT_SUBSCRIBERS_KEY + userId;
+            Boolean isMember = stringRedisTemplate.opsForSet().isMember(subscribersKey, userId.toString());
+
+            boolean isSubscribed = Boolean.TRUE.equals(isMember);
+            log.debug("사용자 구독 상태 확인 - userId: {}, isSubscribed: {}", userId, isSubscribed);
+            return isSubscribed;
+        } catch (Exception e) {
+            log.error("사용자 구독 상태 체크 실패 - userId: {}", userId, e);
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
## 관련 이슈 🛠
<!-- 관련 이슈 번호를 적어주세요. -->
- closes #81 

## 작업 내용 ✏️
<!-- 작업 내용을 간단히 작성해주세요. -->
- [ ] 웹소켓 연결 시 내 채팅방 목록을 구독하고, 읽지 않은 채팅 배지를 업데이트합니다.
- [ ] 웹소켓 연결 해제 시 내 채팅방 목록을 구독해제 합니다.

## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점 등을 필요하다면 작성해주세요. -->
