### PR TITLE
Feat #86 채팅방 생성 api 호출 시 슬롯 개수 체크 로직 추가

### DIFF
--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/auth/business/AuthService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/auth/business/AuthService.java
@@ -54,7 +54,7 @@ public class AuthService {
 
     @Transactional
     public Void withdraw(Long userId, HttpServletResponse response) {
-        User findUser = userRetriever.findById(userId);
+        User findUser = userRetriever.findByIdOrElseThrow(userId);
         oAuthUserInfo.revoke(findUser.getPlatform(), findUser.getSerialId());
         CookieUtil.logoutCookie(response, domain);
         refreshTokenService.deleteRefreshToken(userId);

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/business/ChatRoomService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/business/ChatRoomService.java
@@ -15,6 +15,7 @@ import com.lovesoongalarm.lovesoongalarm.domain.user.exception.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.socket.WebSocketSession;
 
 import java.util.List;
@@ -35,6 +36,7 @@ public class ChatRoomService {
 
     private final ChatRoomConverter chatRoomConverter;
 
+    @Transactional
     public ChatRoom createChatRoom(Long userId, Long targetUserId) {
         log.info("개인 채팅방 생성 시작 - 본인: {}, 상대방: {}", userId, targetUserId);
         userService.validateChatRoomCreation(userId, targetUserId);

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/business/ChatRoomService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/business/ChatRoomService.java
@@ -37,7 +37,7 @@ public class ChatRoomService {
 
     public ChatRoom createChatRoom(Long userId, Long targetUserId) {
         log.info("개인 채팅방 생성 시작 - 본인: {}, 상대방: {}", userId, targetUserId);
-        userService.validateTargetUserExists(targetUserId);
+        userService.validateChatRoomCreation(userId, targetUserId);
         chatRoomValidator.validateChatRoomCreation(userId, targetUserId);
 
         Optional<ChatRoom> existing = chatRoomRetriever.findByIdAndTargetUserId(userId, targetUserId);
@@ -45,8 +45,6 @@ public class ChatRoomService {
             log.info("이미 참여중인 채팅방이므로 채팅방 그대로 반환 - chatRoomId: {}", existing.get().getId());
             return existing.get();
         }
-
-        userService.validateUserSlotAvailability(userId);
 
         ChatRoom newRoom = ChatRoom.create();
         ChatRoom savedRoom = chatRoomSaver.save(newRoom);

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/business/ChatRoomService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/business/ChatRoomService.java
@@ -10,6 +10,7 @@ import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.persistence.entity
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.business.MessageService;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.persistence.entity.ChatRoomParticipant;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.subscription.business.SubscriptionService;
+import com.lovesoongalarm.lovesoongalarm.domain.user.business.UserService;
 import com.lovesoongalarm.lovesoongalarm.domain.user.exception.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,11 +31,13 @@ public class ChatRoomService {
 
     private final MessageService messageService;
     private final SubscriptionService subscriptionService;
+    private final UserService userService;
 
     private final ChatRoomConverter chatRoomConverter;
 
     public ChatRoom createChatRoom(Long userId, Long targetUserId) {
         log.info("개인 채팅방 생성 시작 - 본인: {}, 상대방: {}", userId, targetUserId);
+        userService.validateTargetUserExists(targetUserId);
         chatRoomValidator.validateChatRoomCreation(userId, targetUserId);
 
         Optional<ChatRoom> existing = chatRoomRetriever.findByIdAndTargetUserId(userId, targetUserId);

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/business/ChatRoomService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/business/ChatRoomService.java
@@ -46,6 +46,8 @@ public class ChatRoomService {
             return existing.get();
         }
 
+        userService.validateUserSlotAvailability(userId);
+
         ChatRoom newRoom = ChatRoom.create();
         ChatRoom savedRoom = chatRoomSaver.save(newRoom);
         log.info("개인 채팅방 생성 완료 -  chatRoomId: {}", savedRoom.getId());

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/business/ChatRoomService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/business/ChatRoomService.java
@@ -48,6 +48,9 @@ public class ChatRoomService {
 
         ChatRoom newRoom = ChatRoom.create();
         ChatRoom savedRoom = chatRoomSaver.save(newRoom);
+
+        userService.decreaseRemainingSlot(userId);
+
         log.info("개인 채팅방 생성 완료 -  chatRoomId: {}", savedRoom.getId());
         return savedRoom;
     }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/implement/ChatRoomValidator.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/implement/ChatRoomValidator.java
@@ -14,13 +14,11 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ChatRoomValidator {
 
-    private final UserRetriever userRetriever;
     private final ChatRoomParticipantRetriever chatRoomParticipantRetriever;
     private final ChatRoomRetriever chatRoomRetriever;
 
     public void validateChatRoomCreation(Long userId, Long targetUserId) {
         validateNotSelfChat(userId, targetUserId);
-        validateTargetUserExists(targetUserId);
     }
 
     public void validateChatRoomAccess(Long userId, Long roomId) {
@@ -33,12 +31,6 @@ public class ChatRoomValidator {
     private void validateNotSelfChat(Long userId, Long targetUserId) {
         if (userId.equals(targetUserId)) {
             throw new CustomException(ChatRoomErrorCode.CANNOT_CHAT_WITH_SELF);
-        }
-    }
-
-    private void validateTargetUserExists(Long targetUserId) {
-        if (!userRetriever.existsById(targetUserId)) {
-            throw new CustomException(UserErrorCode.USER_NOT_FOUND);
         }
     }
 

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/application/controller/UserController.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/application/controller/UserController.java
@@ -2,10 +2,7 @@ package com.lovesoongalarm.lovesoongalarm.domain.user.application.controller;
 
 import com.lovesoongalarm.lovesoongalarm.common.BaseResponse;
 import com.lovesoongalarm.lovesoongalarm.common.annotation.UserId;
-import com.lovesoongalarm.lovesoongalarm.domain.user.application.dto.OnBoardingRequestDTO;
-import com.lovesoongalarm.lovesoongalarm.domain.user.application.dto.UserMeResponseDTO;
-import com.lovesoongalarm.lovesoongalarm.domain.user.application.dto.UserResponseDTO;
-import com.lovesoongalarm.lovesoongalarm.domain.user.application.dto.UserUpdateRequestDTO;
+import com.lovesoongalarm.lovesoongalarm.domain.user.application.dto.*;
 import com.lovesoongalarm.lovesoongalarm.domain.user.business.UserQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -66,5 +63,13 @@ public class UserController {
             ){
 
         return BaseResponse.success(userQueryService.updateUser(userId, updateRequest));
+    }
+
+    @GetMapping("/slots")
+    @Operation(summary = "유저 최대 슬롯 개수 조회",
+            description = "유저의 최대 슬롯 개수가 몇 개인지 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "최대 슬롯 개수 조회 성공")
+    public BaseResponse<UserSlotResponseDTO> getUserSlots(@UserId Long userId){
+        return BaseResponse.success(userQueryService.getUserSlots(userId));
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/application/converter/UserConverter.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/application/converter/UserConverter.java
@@ -1,0 +1,14 @@
+package com.lovesoongalarm.lovesoongalarm.domain.user.application.converter;
+
+import com.lovesoongalarm.lovesoongalarm.domain.user.application.dto.UserSlotResponseDTO;
+import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserConverter {
+    public UserSlotResponseDTO createSlotInfo(User user) {
+        return UserSlotResponseDTO.builder()
+                .maxSlots(user.getMaxSlot())
+                .build();
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/application/dto/UserSlotResponseDTO.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/application/dto/UserSlotResponseDTO.java
@@ -1,0 +1,9 @@
+package com.lovesoongalarm.lovesoongalarm.domain.user.application.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UserSlotResponseDTO(
+        Integer maxSlots
+) {
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/business/UserQueryService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/business/UserQueryService.java
@@ -1,6 +1,7 @@
 package com.lovesoongalarm.lovesoongalarm.domain.user.business;
 
 import com.lovesoongalarm.lovesoongalarm.common.exception.CustomException;
+import com.lovesoongalarm.lovesoongalarm.domain.user.application.converter.UserConverter;
 import com.lovesoongalarm.lovesoongalarm.domain.user.application.dto.*;
 import com.lovesoongalarm.lovesoongalarm.domain.user.application.dto.OnBoardingRequestDTO;
 import com.lovesoongalarm.lovesoongalarm.domain.user.application.dto.UserResponseDTO;
@@ -32,6 +33,7 @@ public class UserQueryService {
     private final UserRetriever userRetriever;
     private final InterestSaver interestSaver;
     private final StringRedisTemplate stringRedisTemplate;
+    private final UserConverter userConverter;
 
     public String getUserNickname(Long userId) {
         User user = userRetriever.findByIdOrElseThrow(userId);
@@ -117,6 +119,12 @@ public class UserQueryService {
         return null;
     }
 
+    public UserSlotResponseDTO getUserSlots(Long userId) {
+        User user = userRetriever.findById(userId);
+        UserSlotResponseDTO slotInfo = userConverter.createSlotInfo(user);
+        return slotInfo;
+    }
+
     private int calculateAge(Integer birthDate){
         int currentYear = LocalDate.now().getYear();
         int age = currentYear - birthDate + 1;
@@ -140,5 +148,4 @@ public class UserQueryService {
 
         stringRedisTemplate.opsForHash().put(USER_GENDER_KEY, String.valueOf(userId), gender.name());
     }
-
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/business/UserQueryService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/business/UserQueryService.java
@@ -42,7 +42,7 @@ public class UserQueryService {
 
     @Transactional
     public Void onBoardingUser(Long userId, OnBoardingRequestDTO request){
-        User findUser = userRetriever.findById(userId);
+        User findUser = userRetriever.findByIdOrElseThrow(userId);
         findUser.updateFromOnboardingAndProfile(request.nickname(), request.major(), request.birthDate(), EGender.valueOf(request.gender()), request.emoji());
 
         List<Interest> interests = request.interests().stream()
@@ -72,7 +72,7 @@ public class UserQueryService {
     }
 
     public UserResponseDTO getUser(Long targetId){
-        User findUser = userRetriever.findById(targetId);
+        User findUser = userRetriever.findByIdOrElseThrow(targetId);
 
         int age = calculateAge(findUser.getBirthDate());
 
@@ -80,14 +80,14 @@ public class UserQueryService {
     }
 
     public UserMeResponseDTO getMe(Long userId){
-        User findUser = userRetriever.findById(userId);
+        User findUser = userRetriever.findByIdOrElseThrow(userId);
 
         return UserMeResponseDTO.from(findUser);
     }
 
     @Transactional
     public Void updateUser(Long userId, UserUpdateRequestDTO request){
-        User findUser = userRetriever.findById(userId);
+        User findUser = userRetriever.findByIdOrElseThrow(userId);
         findUser.updateFromOnboardingAndProfile(request.nickname(), request.major(), request.birthDate(), EGender.valueOf(request.gender()), request.emoji());
 
         List<Interest> existingInterests = findUser.getInterests();
@@ -120,7 +120,7 @@ public class UserQueryService {
     }
 
     public UserSlotResponseDTO getUserSlots(Long userId) {
-        User user = userRetriever.findById(userId);
+        User user = userRetriever.findByIdOrElseThrow(userId);
         UserSlotResponseDTO slotInfo = userConverter.createSlotInfo(user);
         return slotInfo;
     }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/business/UserService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/business/UserService.java
@@ -29,11 +29,7 @@ public class UserService {
         return partner;
     }
 
-    public void validateTargetUserExists(Long targetUserId) {
-        userValidator.validateTargetUserExists(targetUserId);
-    }
-
-    public void validateUserSlotAvailability(Long userId) {
-        userValidator.validateUserSlotAvailability(userId);
+    public void validateChatRoomCreation(Long userId, Long targetUserId) {
+        userValidator.validateChatRoomCreation(userId, targetUserId);
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/business/UserService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/business/UserService.java
@@ -30,9 +30,7 @@ public class UserService {
     }
 
     public void validateTargetUserExists(Long targetUserId) {
-        if (!userRetriever.existsById(targetUserId)) {
-            throw new CustomException(UserErrorCode.USER_NOT_FOUND);
-        }
+        userValidator.validateTargetUserExists(targetUserId);
     }
 
     public void validateUserSlotAvailability(Long userId) {

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/business/UserService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/business/UserService.java
@@ -1,5 +1,7 @@
 package com.lovesoongalarm.lovesoongalarm.domain.user.business;
 
+import com.lovesoongalarm.lovesoongalarm.common.exception.CustomException;
+import com.lovesoongalarm.lovesoongalarm.domain.user.exception.UserErrorCode;
 import com.lovesoongalarm.lovesoongalarm.domain.user.implement.UserRetriever;
 import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -22,5 +24,11 @@ public class UserService {
         User partner = userRetriever.findPartnerByChatRoomIdAndUserId(roomId, userId);
         log.info("채팅방의 상대방 사용자 정보 조회 완료 - roomId: {}, partnerId: {}", roomId, partner.getId());
         return partner;
+    }
+
+    public void validateTargetUserExists(Long targetUserId) {
+        if (!userRetriever.existsById(targetUserId)) {
+            throw new CustomException(UserErrorCode.USER_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/business/UserService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/business/UserService.java
@@ -1,11 +1,9 @@
 package com.lovesoongalarm.lovesoongalarm.domain.user.business;
 
-import com.lovesoongalarm.lovesoongalarm.common.exception.CustomException;
-import com.lovesoongalarm.lovesoongalarm.domain.user.exception.UserErrorCode;
 import com.lovesoongalarm.lovesoongalarm.domain.user.implement.UserRetriever;
+import com.lovesoongalarm.lovesoongalarm.domain.user.implement.UserUpdater;
 import com.lovesoongalarm.lovesoongalarm.domain.user.implement.UserValidator;
 import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.User;
-import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,6 +15,7 @@ public class UserService {
 
     private final UserRetriever userRetriever;
     private final UserValidator userValidator;
+    private final UserUpdater userUpdater;
 
     public User findUserOrElseThrow(Long userId) {
         return userRetriever.findByIdOrElseThrow(userId);
@@ -31,5 +30,9 @@ public class UserService {
 
     public void validateChatRoomCreation(Long userId, Long targetUserId) {
         userValidator.validateChatRoomCreation(userId, targetUserId);
+    }
+
+    public void decreaseRemainingSlot(Long userId) {
+        userUpdater.decreaseRemainingSlot(userId);
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/business/UserService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/business/UserService.java
@@ -1,5 +1,7 @@
 package com.lovesoongalarm.lovesoongalarm.domain.user.business;
 
+import com.lovesoongalarm.lovesoongalarm.common.exception.CustomException;
+import com.lovesoongalarm.lovesoongalarm.domain.user.exception.UserErrorCode;
 import com.lovesoongalarm.lovesoongalarm.domain.user.implement.UserRetriever;
 import com.lovesoongalarm.lovesoongalarm.domain.user.implement.UserUpdater;
 import com.lovesoongalarm.lovesoongalarm.domain.user.implement.UserValidator;
@@ -7,6 +9,7 @@ import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -32,10 +35,14 @@ public class UserService {
         userValidator.validateChatRoomCreation(userId, targetUserId);
     }
 
+    @Transactional
     public void decreaseRemainingSlot(Long userId) {
         User user = userRetriever.findByIdOrElseThrow(userId);
         if (user.isPrePass()) return;
 
-        userUpdater.decreaseRemainingSlot(userId);
+        int updatedRows = userUpdater.decreaseRemainingSlot(userId);
+        if (updatedRows == 0) {
+            throw new CustomException(UserErrorCode.INSUFFICIENT_CHAT_SLOTS);
+        }
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/business/UserService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/business/UserService.java
@@ -33,6 +33,9 @@ public class UserService {
     }
 
     public void decreaseRemainingSlot(Long userId) {
+        User user = userRetriever.findByIdOrElseThrow(userId);
+        if (user.isPrePass()) return;
+
         userUpdater.decreaseRemainingSlot(userId);
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/business/UserService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/business/UserService.java
@@ -3,7 +3,9 @@ package com.lovesoongalarm.lovesoongalarm.domain.user.business;
 import com.lovesoongalarm.lovesoongalarm.common.exception.CustomException;
 import com.lovesoongalarm.lovesoongalarm.domain.user.exception.UserErrorCode;
 import com.lovesoongalarm.lovesoongalarm.domain.user.implement.UserRetriever;
+import com.lovesoongalarm.lovesoongalarm.domain.user.implement.UserValidator;
 import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.User;
+import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
     private final UserRetriever userRetriever;
+    private final UserValidator userValidator;
 
     public User findUserOrElseThrow(Long userId) {
         return userRetriever.findByIdOrElseThrow(userId);
@@ -30,5 +33,9 @@ public class UserService {
         if (!userRetriever.existsById(targetUserId)) {
             throw new CustomException(UserErrorCode.USER_NOT_FOUND);
         }
+    }
+
+    public void validateUserSlotAvailability(Long userId) {
+        userValidator.validateUserSlotAvailability(userId);
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/exception/UserErrorCode.java
@@ -9,7 +9,8 @@ public enum UserErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
     INVALID_USER(HttpStatus.BAD_REQUEST, "유효하지 않은 유저입니다."),
     INVALID_USER_AGE(HttpStatus.BAD_REQUEST, "나이는 음수일 수 없습니다."),
-    USER_GENDER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 성별을 찾을 수 없습니다.");
+    USER_GENDER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 성별을 찾을 수 없습니다."),
+    INSUFFICIENT_CHAT_SLOTS(HttpStatus.BAD_REQUEST, "사용 가능한 채팅 슬롯이 존재하지 않습니다." );
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/implement/UserRetriever.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/implement/UserRetriever.java
@@ -22,11 +22,6 @@ public class UserRetriever {
         return userRepository.existsById(targetUserId);
     }
 
-    public User findById(Long userId){
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
-    }
-
     public User findPartnerByChatRoomIdAndUserId(Long roomId, Long userId) {
         return userRepository.findPartnerByChatRoomIdAndUserId(roomId, userId);
     }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/implement/UserUpdater.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/implement/UserUpdater.java
@@ -1,0 +1,18 @@
+package com.lovesoongalarm.lovesoongalarm.domain.user.implement;
+
+import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserUpdater {
+
+    private final UserRepository userRepository;
+
+    public void decreaseRemainingSlot(Long userId) {
+        userRepository.decreaseRemainingSlot(userId);
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/implement/UserUpdater.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/implement/UserUpdater.java
@@ -4,6 +4,7 @@ import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.repository.User
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -12,7 +13,14 @@ public class UserUpdater {
 
     private final UserRepository userRepository;
 
-    public void decreaseRemainingSlot(Long userId) {
-        userRepository.decreaseRemainingSlot(userId);
+    @Transactional
+    public int decreaseRemainingSlot(Long userId) {
+        int updatedRows = userRepository.decreaseRemainingSlot(userId);
+
+        if (updatedRows == 0) {
+            log.warn("슬롯 감소 실패 - 사용 가능한 슬롯이 없거나 사용자가 존재하지 않음 - userId: {}", userId);
+            return 0;
+        }
+        return updatedRows;
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/implement/UserValidator.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/implement/UserValidator.java
@@ -1,0 +1,23 @@
+package com.lovesoongalarm.lovesoongalarm.domain.user.implement;
+
+import com.lovesoongalarm.lovesoongalarm.common.exception.CustomException;
+import com.lovesoongalarm.lovesoongalarm.domain.user.exception.UserErrorCode;
+import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class UserValidator {
+
+    private final UserRetriever userRetriever;
+
+    public void validateUserSlotAvailability(Long userId) {
+        User user = userRetriever.findByIdOrElseThrow(userId);
+        if(!user.hasAvailableSlot()){
+            throw new CustomException(UserErrorCode.INSUFFICIENT_CHAT_SLOTS);
+        }
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/implement/UserValidator.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/implement/UserValidator.java
@@ -14,6 +14,12 @@ public class UserValidator {
 
     private final UserRetriever userRetriever;
 
+    public void validateTargetUserExists(Long targetUserId) {
+        if (!userRetriever.existsById(targetUserId)) {
+            throw new CustomException(UserErrorCode.USER_NOT_FOUND);
+        }
+    }
+
     public void validateUserSlotAvailability(Long userId) {
         User user = userRetriever.findByIdOrElseThrow(userId);
         if(!user.hasAvailableSlot()){

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/implement/UserValidator.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/implement/UserValidator.java
@@ -14,13 +14,18 @@ public class UserValidator {
 
     private final UserRetriever userRetriever;
 
-    public void validateTargetUserExists(Long targetUserId) {
+    public void validateChatRoomCreation(Long userId, Long targetUserId) {
+        validateTargetUserExists(targetUserId);
+        validateUserSlotAvailability(userId);
+    }
+
+    private void validateTargetUserExists(Long targetUserId) {
         if (!userRetriever.existsById(targetUserId)) {
             throw new CustomException(UserErrorCode.USER_NOT_FOUND);
         }
     }
 
-    public void validateUserSlotAvailability(Long userId) {
+    private void validateUserSlotAvailability(Long userId) {
         User user = userRetriever.findByIdOrElseThrow(userId);
         if(!user.hasAvailableSlot()){
             throw new CustomException(UserErrorCode.INSUFFICIENT_CHAT_SLOTS);

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/implement/UserValidator.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/implement/UserValidator.java
@@ -27,6 +27,7 @@ public class UserValidator {
 
     private void validateUserSlotAvailability(Long userId) {
         User user = userRetriever.findByIdOrElseThrow(userId);
+        if (user.isPrePass()) return;
         if(!user.hasAvailableSlot()){
             throw new CustomException(UserErrorCode.INSUFFICIENT_CHAT_SLOTS);
         }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/entity/User.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/entity/User.java
@@ -5,7 +5,6 @@ import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.type.EPl
 import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.type.ERole;
 import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.type.EUserStatus;
 import com.lovesoongalarm.lovesoongalarm.domain.user.sub.interest.persistence.entity.Interest;
-import com.lovesoongalarm.lovesoongalarm.domain.user.sub.interest.sub.hashtag.persistence.entity.Hashtag;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -69,41 +68,31 @@ public class User {
     @Column(name = "max_slot")
     private Integer maxSlot;
 
-    @Column(name = "slot")
-    private Integer slot;
+    @Column(name = "remaining_slot")
+    private Integer remainingSlot;
 
     @Builder
-    public User(Long id, String nickname, EPlatform platform, ERole role, String serialId, EUserStatus status, String major, Integer birthDate, EGender gender, String emoji, Integer chatTicket, Integer maxSlot, Integer slot, boolean prePass) {
-        this.id = id;
-        this.nickname = nickname;
+    private User(EPlatform platform, ERole role, String serialId, EUserStatus status, Integer chatTicket, Integer maxSlot, Integer remainingSlot, boolean prePass) {
         this.platform = platform;
         this.role = role;
         this.serialId = serialId;
         this.status = status;
-        this.major = major;
-        this.birthDate = birthDate;
-        this.gender = gender;
-        this.emoji = emoji;
         this.chatTicket = chatTicket;
         this.maxSlot = maxSlot;
-        this.slot = slot;
+        this.remainingSlot = remainingSlot;
         this.prePass = prePass;
     }
 
-    public static User create(String nickname, EPlatform platform, ERole role, String serialId, EUserStatus status, String major, Integer birthDate, EGender gender, String emoji, Integer chatTicket, Integer slot, boolean prePass) {
+    public static User create(String serialId, EPlatform platform, ERole role, EUserStatus status) {
         return User.builder()
-                .nickname(nickname)
                 .platform(platform)
                 .serialId(serialId)
                 .role(role)
                 .status(status)
-                .major(major)
-                .birthDate(birthDate)
-                .gender(gender)
-                .emoji(emoji)
-                .chatTicket(chatTicket)
-                .slot(slot)
-                .prePass(prePass)
+                .chatTicket(0)
+                .maxSlot(1)
+                .remainingSlot(0)
+                .prePass(false)
                 .build();
     }
 
@@ -130,7 +119,7 @@ public class User {
     public void updateFromOnboardingAndProfile(String nickname, String major, Integer birthDate, EGender gender, String emoji) {
         this.nickname = nickname;
         this.major = major;
-        this.birthDate =birthDate;
+        this.birthDate = birthDate;
         this.gender = gender;
         this.emoji = emoji;
         this.status = EUserStatus.ACTIVE;

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/entity/User.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/entity/User.java
@@ -57,19 +57,19 @@ public class User {
     private String emoji;
 
     @Column(name = "chat_ticket")
-    private Integer chatTicket;
+    private Integer chatTicket = 0;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Interest> interests = new ArrayList<>();
 
     @Column(name = "pre_pass")
-    private boolean prePass;
+    private boolean prePass = false;
 
     @Column(name = "max_slot")
-    private Integer maxSlot;
+    private Integer maxSlot = 1;
 
     @Column(name = "remaining_slot")
-    private Integer remainingSlot;
+    private Integer remainingSlot = 1;
 
     @Builder
     private User(EPlatform platform, ERole role, String serialId, EUserStatus status, Integer chatTicket, Integer maxSlot, Integer remainingSlot, boolean prePass) {
@@ -91,7 +91,7 @@ public class User {
                 .status(status)
                 .chatTicket(0)
                 .maxSlot(1)
-                .remainingSlot(0)
+                .remainingSlot(1)
                 .prePass(false)
                 .build();
     }
@@ -123,5 +123,12 @@ public class User {
         this.gender = gender;
         this.emoji = emoji;
         this.status = EUserStatus.ACTIVE;
+    }
+
+    public boolean hasAvailableSlot() {
+        if( this.remainingSlot != null && this.remainingSlot > 0 ) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/entity/User.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/entity/User.java
@@ -6,6 +6,8 @@ import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.type.ERo
 import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.type.EUserStatus;
 import com.lovesoongalarm.lovesoongalarm.domain.user.sub.interest.persistence.entity.Interest;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -57,6 +59,7 @@ public class User {
     private String emoji;
 
     @Column(name = "chat_ticket")
+    @NotNull @Min(0)
     private Integer chatTicket = 0;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -65,10 +68,12 @@ public class User {
     @Column(name = "pre_pass")
     private boolean prePass = false;
 
-    @Column(name = "max_slot")
+    @Column(name = "max_slot", nullable = false)
+    @NotNull @Min(1)
     private Integer maxSlot = 1;
 
-    @Column(name = "remaining_slot")
+    @Column(name = "remaining_slot", nullable = false)
+    @NotNull @Min(0)
     private Integer remainingSlot = 1;
 
     @Builder

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/entity/User.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/entity/User.java
@@ -66,11 +66,14 @@ public class User {
     @Column(name = "pre_pass")
     private boolean prePass;
 
+    @Column(name = "max_slot")
+    private Integer maxSlot;
+
     @Column(name = "slot")
     private Integer slot;
 
     @Builder
-    public User(Long id, String nickname, EPlatform platform, ERole role, String serialId, EUserStatus status, String major, Integer birthDate, EGender gender, String emoji, Integer chatTicket, Integer slot, boolean prePass) {
+    public User(Long id, String nickname, EPlatform platform, ERole role, String serialId, EUserStatus status, String major, Integer birthDate, EGender gender, String emoji, Integer chatTicket, Integer maxSlot, Integer slot, boolean prePass) {
         this.id = id;
         this.nickname = nickname;
         this.platform = platform;
@@ -82,6 +85,7 @@ public class User {
         this.gender = gender;
         this.emoji = emoji;
         this.chatTicket = chatTicket;
+        this.maxSlot = maxSlot;
         this.slot = slot;
         this.prePass = prePass;
     }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/repository/UserRepository.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/repository/UserRepository.java
@@ -1,10 +1,10 @@
 package com.lovesoongalarm.lovesoongalarm.domain.user.persistence.repository;
 
 import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.User;
-import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/repository/UserRepository.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/repository/UserRepository.java
@@ -31,7 +31,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
             """)
     User findPartnerByChatRoomIdAndUserId(@Param("roomId") Long roomId, @Param("userId") Long userId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("""
             UPDATE User u 
             SET u.remainingSlot = u.remainingSlot - 1 

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/repository/UserRepository.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/repository/UserRepository.java
@@ -3,6 +3,7 @@ package com.lovesoongalarm.lovesoongalarm.domain.user.persistence.repository;
 import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.User;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
@@ -16,8 +17,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("select u.id as id, u.role as role, u.status as status from User u where u.id = :id")
     Optional<UserSecurityForm> findUserSecurityFromById(@Param("id") Long id);
 
-    // query method
-    Optional<User> findBySerialId(String serialId);
     Optional<User> findById(Long id);
 
     @Query("""
@@ -31,4 +30,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
             )
             """)
     User findPartnerByChatRoomIdAndUserId(@Param("roomId") Long roomId, @Param("userId") Long userId);
+
+    @Modifying
+    @Query("""
+            UPDATE User u 
+            SET u.remainingSlot = u.remainingSlot - 1 
+            WHERE u.id = :userId 
+            AND u.remainingSlot > 0
+            """)
+    void decreaseRemainingSlot(@Param("userId") Long userId);
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/repository/UserRepository.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/repository/UserRepository.java
@@ -38,5 +38,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
             WHERE u.id = :userId 
             AND u.remainingSlot > 0
             """)
-    void decreaseRemainingSlot(@Param("userId") Long userId);
+    int decreaseRemainingSlot(@Param("userId") Long userId);
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/security/service/CustomOauth2UserDetailService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/security/service/CustomOauth2UserDetailService.java
@@ -49,6 +49,9 @@ public class CustomOauth2UserDetailService extends DefaultOAuth2UserService {
                                     .platform(platform)
                                     .role(ERole.USER)
                                     .status(EUserStatus.INACTIVE)
+                                    .maxSlot(1)
+                                    .slot(0)
+                                    .chatTicket(0)
                                     .build()
                     );
                     return UserSecurityForm.invoke(newUser);

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/security/service/CustomOauth2UserDetailService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/security/service/CustomOauth2UserDetailService.java
@@ -44,16 +44,7 @@ public class CustomOauth2UserDetailService extends DefaultOAuth2UserService {
 
                     // 새 User 엔티티 생성 및 저장
                     User newUser = userRepository.save(
-                            User.builder()
-                                    .serialId(oauth2UserInfo.getId())
-                                    .platform(platform)
-                                    .role(ERole.USER)
-                                    .status(EUserStatus.INACTIVE)
-                                    .maxSlot(1)
-                                    .slot(0)
-                                    .chatTicket(0)
-                                    .build()
-                    );
+                            User.create(oauth2UserInfo.getId(), platform, ERole.USER, EUserStatus.INACTIVE));
                     return UserSecurityForm.invoke(newUser);
                 });
         log.info("oauth2 사용자 조회 성공");


### PR DESCRIPTION
## 관련 이슈 🛠
<!-- 관련 이슈 번호를 적어주세요. -->
- closes #86 

## 작업 내용 ✏️
<!-- 작업 내용을 간단히 작성해주세요. -->
- [ ] 유저 엔티티에 slot 관련 필드를 변경하고, 생성하는 로직에서 create 메서드를 사용하도록 변경했습니다.
- [ ] 그리고 채팅방 생성 시 remainingSlot 개수를 체크하고, 슈퍼패스 여부를 체크합니다.
- [ ] 내 최대 채팅 슬롯 개수를 반환하는 API를 구현했습니다.

## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점 등을 필요하다면 작성해주세요. -->
