### PR TITLE
Feat #94 채팅 송신 시 메시지 개수와 티켓 사용 여부 체크 로직 구현

### DIFF
--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/application/dto/WebSocketMessageDTO.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/application/dto/WebSocketMessageDTO.java
@@ -71,6 +71,12 @@ public class WebSocketMessageDTO {
     }
 
     @Builder
+    public record MessageCountLimit(
+            EWebSocketMessageType type
+    ) {
+    }
+
+    @Builder
     public record ErrorResponse(
             EWebSocketMessageType type,
             String errorCode,

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/persistence/type/EWebSocketMessageType.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/persistence/type/EWebSocketMessageType.java
@@ -14,6 +14,7 @@ public enum EWebSocketMessageType {
     CHAT_MESSAGE("채팅 메시지"),
     UNREAD_BADGE_UPDATE("안 읽은 메시지 배지 업데이트"),
     CHAT_LIST_UPDATE("채팅방 목록 업데이트"),
+    MESSAGE_COUNT_LIMIT("채팅방 메시지 제한"),
     ERROR("에러");
 
     private final String value;

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/MessageService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/MessageService.java
@@ -10,6 +10,7 @@ import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.implem
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.implement.MessageValidator;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.persistence.entity.Message;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.business.ChatRoomParticipantService;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.business.ChatTicketService;
 import com.lovesoongalarm.lovesoongalarm.domain.user.business.UserService;
 import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -35,7 +36,7 @@ public class MessageService {
 
     private final UserService userService;
     private final ChatRoomParticipantService chatRoomParticipantService;
-    private final MessageNotificationService messageNotificationService;
+    private final ChatTicketService chatTicketService;
 
     private final ApplicationEventPublisher eventPublisher;
 
@@ -125,6 +126,7 @@ public class MessageService {
     @Transactional
     public void sendMessage(ChatRoom chatRoom, String content, Long senderId) {
         log.info("1:1 채팅 메시지 전송 시작 - chatRoomId: {}, senderId: {}", chatRoom.getId(), senderId);
+        chatTicketService.validateAndProcessMessage(senderId, chatRoom.getId());
         messageValidator.validateMessage(content);
 
         User sender = userService.findUserOrElseThrow(senderId);

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/WebSocketMessageService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/WebSocketMessageService.java
@@ -116,5 +116,7 @@ public class WebSocketMessageService {
         WebSocketMessageDTO.MessageCountLimit messageCountLimit = WebSocketMessageDTO.MessageCountLimit.builder()
                 .type(EWebSocketMessageType.MESSAGE_COUNT_LIMIT)
                 .build();
+
+        messageSender.sendMessage(session, messageCountLimit);
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/WebSocketMessageService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/WebSocketMessageService.java
@@ -112,4 +112,9 @@ public class WebSocketMessageService {
         messageSender.sendMessage(session, chatListUpdate);
     }
 
+    public void sendMessageCountLimit(WebSocketSession session){
+        WebSocketMessageDTO.MessageCountLimit messageCountLimit = WebSocketMessageDTO.MessageCountLimit.builder()
+                .type(EWebSocketMessageType.MESSAGE_COUNT_LIMIT)
+                .build();
+    }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/business/ChatTicketService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/business/ChatTicketService.java
@@ -2,6 +2,7 @@ package com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.b
 
 import com.lovesoongalarm.lovesoongalarm.common.exception.CustomException;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.business.WebSocketMessageService;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.exception.ChatRoomParticipantErrorCode;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.implement.ChatRoomParticipantRetriever;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.implement.ChatRoomParticipantUpdater;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.persistence.entity.ChatRoomParticipant;
@@ -40,6 +41,7 @@ public class ChatTicketService {
 
         if (participant.getFreeMessageCount() >= FREE_MESSAGE_LIMIT) {
             webSocketMessageService.sendMessageCountLimit(session);
+            throw new CustomException(ChatRoomParticipantErrorCode.EXCEED_MESSAGE_LIMIT);
         }
         chatRoomParticipantUpdater.incrementFreeMessageCount(participant.getId());
     }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/business/ChatTicketService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/business/ChatTicketService.java
@@ -1,11 +1,16 @@
 package com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.business;
 
+import com.lovesoongalarm.lovesoongalarm.common.exception.CustomException;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.business.WebSocketMessageService;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.implement.ChatRoomParticipantRetriever;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.implement.ChatRoomParticipantUpdater;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.persistence.entity.ChatRoomParticipant;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.session.business.ChatSessionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.socket.WebSocketSession;
 
 @Service
 @Slf4j
@@ -14,14 +19,26 @@ public class ChatTicketService {
 
     private final ChatRoomParticipantRetriever chatRoomParticipantRetriever;
 
+    private final WebSocketMessageService webSocketMessageService;
+    private final ChatSessionService chatSessionService;
+
+    private static final int FREE_MESSAGE_LIMIT = 10;
+
     @Transactional
     public void validateAndProcessMessage(Long userId, Long chatRoomId) {
         ChatRoomParticipant participant = chatRoomParticipantRetriever
                 .findByUserIdAndChatRoomId(userId, chatRoomId);
 
-        if (participant.hasUnlimitedChat()){
+        if (participant.hasUnlimitedChat()) return;
+
+        WebSocketSession session = chatSessionService.getSession(userId);
+        if (session == null || !session.isOpen()) {
+            log.debug("사용자 세션이 없거나 닫혀있음 - userId: {}", userId);
             return;
         }
 
+        if (participant.getFreeMessageCount() >= FREE_MESSAGE_LIMIT) {
+            webSocketMessageService.sendMessageCountLimit(session);
+        }
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/business/ChatTicketService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/business/ChatTicketService.java
@@ -18,6 +18,7 @@ import org.springframework.web.socket.WebSocketSession;
 public class ChatTicketService {
 
     private final ChatRoomParticipantRetriever chatRoomParticipantRetriever;
+    private final ChatRoomParticipantUpdater chatRoomParticipantUpdater;
 
     private final WebSocketMessageService webSocketMessageService;
     private final ChatSessionService chatSessionService;
@@ -40,5 +41,6 @@ public class ChatTicketService {
         if (participant.getFreeMessageCount() >= FREE_MESSAGE_LIMIT) {
             webSocketMessageService.sendMessageCountLimit(session);
         }
+        chatRoomParticipantUpdater.incrementFreeMessageCount(participant.getId());
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/business/ChatTicketService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/business/ChatTicketService.java
@@ -1,0 +1,23 @@
+package com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.business;
+
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.implement.ChatRoomParticipantRetriever;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.persistence.entity.ChatRoomParticipant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ChatTicketService {
+
+    private final ChatRoomParticipantRetriever chatRoomParticipantRetriever;
+
+    @Transactional
+    public void validateAndProcessMessage(Long userId, Long chatRoomId) {
+        ChatRoomParticipant participant = chatRoomParticipantRetriever
+                .findByUserIdAndChatRoomId(userId, chatRoomId);
+
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/business/ChatTicketService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/business/ChatTicketService.java
@@ -19,5 +19,9 @@ public class ChatTicketService {
         ChatRoomParticipant participant = chatRoomParticipantRetriever
                 .findByUserIdAndChatRoomId(userId, chatRoomId);
 
+        if (participant.hasUnlimitedChat()){
+            return;
+        }
+
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/exception/ChatRoomParticipantErrorCode.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/exception/ChatRoomParticipantErrorCode.java
@@ -1,0 +1,23 @@
+package com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.exception;
+
+import com.lovesoongalarm.lovesoongalarm.common.code.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ChatRoomParticipantErrorCode implements ErrorCode {
+    EXCEED_MESSAGE_LIMIT(HttpStatus.BAD_REQUEST, "보낼 수 있는 메시지 제한을 넘겼습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/implement/ChatRoomParticipantRetriever.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/implement/ChatRoomParticipantRetriever.java
@@ -1,5 +1,7 @@
 package com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.implement;
 
+import com.lovesoongalarm.lovesoongalarm.common.exception.CustomException;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.exception.ChatRoomErrorCode;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.persistence.entity.ChatRoomParticipant;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.persistence.repository.ChatRoomParticipantRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,5 +17,10 @@ public class ChatRoomParticipantRetriever {
 
     public boolean existsByUserIdAndChatRoomId(Long userId, Long chatRoomId) {
         return chatRoomParticipantRepository.existsByUser_IdAndChatRoom_Id(userId, chatRoomId);
+    }
+
+    public ChatRoomParticipant findByUserIdAndChatRoomId(Long userId, Long chatRoomId) {
+        return chatRoomParticipantRepository.findByUser_IdAndChatRoom_Id(userId, chatRoomId)
+                .orElseThrow(() -> new CustomException(ChatRoomErrorCode.CHAT_ROOM_ACCESS_DENIED));
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/implement/ChatRoomParticipantUpdater.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/implement/ChatRoomParticipantUpdater.java
@@ -4,6 +4,7 @@ import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.pe
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @Slf4j
@@ -14,5 +15,10 @@ public class ChatRoomParticipantUpdater {
 
     public void updateParticipantStatusToJoined(Long participantId) {
         chatRoomParticipantRepository.updateStatusToJoined(participantId);
+    }
+
+    @Transactional
+    public void incrementFreeMessageCount(Long participantId) {
+        chatRoomParticipantRepository.incrementFreeMessageCount(participantId);
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/persistence/entity/ChatRoomParticipant.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/persistence/entity/ChatRoomParticipant.java
@@ -20,6 +20,12 @@ public class ChatRoomParticipant {
     @Column(nullable = false)
     private EChatRoomParticipantStatus status = EChatRoomParticipantStatus.PENDING;
 
+    @Column(name = "free_message_count", nullable = false)
+    private Integer freeMessageCount = 0;
+
+    @Column(name = "ticket_used", nullable = false)
+    private Boolean ticketUsed = false;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
@@ -33,6 +39,8 @@ public class ChatRoomParticipant {
         this.status = status;
         this.chatRoom = chatRoom;
         this.user = user;
+        this.freeMessageCount = 0;
+        this.ticketUsed = false;
     }
 
     public static ChatRoomParticipant createJoined(ChatRoom chatRoom, User me) {
@@ -49,5 +57,9 @@ public class ChatRoomParticipant {
                 .chatRoom(chatRoom)
                 .user(target)
                 .build();
+    }
+
+    public boolean hasUnlimitedChat() {
+        return this.getUser().isPrePass() || this.getTicketUsed();
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/persistence/repository/ChatRoomParticipantRepository.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/persistence/repository/ChatRoomParticipantRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface ChatRoomParticipantRepository extends JpaRepository<ChatRoomParticipant, Long> {
 
     boolean existsByUser_IdAndChatRoom_Id(Long userId, Long chatRoomId);
@@ -17,4 +19,6 @@ public interface ChatRoomParticipantRepository extends JpaRepository<ChatRoomPar
             WHERE p.id = :participantId
             """)
     void updateStatusToJoined(@Param("participantId") Long participantId);
+
+    Optional<ChatRoomParticipant> findByUser_IdAndChatRoom_Id(Long userId, Long chatRoomId);
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/persistence/repository/ChatRoomParticipantRepository.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/persistence/repository/ChatRoomParticipantRepository.java
@@ -20,5 +20,13 @@ public interface ChatRoomParticipantRepository extends JpaRepository<ChatRoomPar
             """)
     void updateStatusToJoined(@Param("participantId") Long participantId);
 
-    Optional<ChatRoomParticipant> findByUser_IdAndChatRoom_Id(Long userId, Long chatRoomId);
+    @Query("""
+            SELECT crp FROM ChatRoomParticipant crp
+            JOIN FETCH crp.user u
+            WHERE crp.user.id = :userId
+            AND crp.chatRoom.id = :chatRoomId
+            """)
+    Optional<ChatRoomParticipant> findByUser_IdAndChatRoom_Id(
+            @Param("userId") Long userId,
+            @Param("chatRoomId") Long chatRoomId);
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/persistence/repository/ChatRoomParticipantRepository.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/persistence/repository/ChatRoomParticipantRepository.java
@@ -29,4 +29,13 @@ public interface ChatRoomParticipantRepository extends JpaRepository<ChatRoomPar
     Optional<ChatRoomParticipant> findByUser_IdAndChatRoom_Id(
             @Param("userId") Long userId,
             @Param("chatRoomId") Long chatRoomId);
+
+    @Modifying
+    @Query("""
+            UPDATE ChatRoomParticipant p 
+            SET p.freeMessageCount = p.freeMessageCount + 1 
+            WHERE p.id = :participantId 
+            AND p.ticketUsed = false
+            """)
+    void incrementFreeMessageCount(@Param("participantId") Long participantId);
 }


### PR DESCRIPTION
## 관련 이슈 🛠
<!-- 관련 이슈 번호를 적어주세요. -->
- closes #94 

## 작업 내용 ✏️
<!-- 작업 내용을 간단히 작성해주세요. -->
- [ ] 채팅 송신 시 프리패스 여부와 티켓 사용 여부를 체크하고, 보낸 메시지 개수를 체크하는 로직을 구현했습니다.

## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점 등을 필요하다면 작성해주세요. -->
