### PR TITLE
Fix #110 채팅방 존재 여부 확인 전 슬롯 개수 체크하는 로직 변경

### DIFF
--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/business/ChatRoomService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/business/ChatRoomService.java
@@ -39,14 +39,14 @@ public class ChatRoomService {
     @Transactional
     public ChatRoom createChatRoom(Long userId, Long targetUserId) {
         log.info("개인 채팅방 생성 시작 - 본인: {}, 상대방: {}", userId, targetUserId);
-        userService.validateChatRoomCreation(userId, targetUserId);
-        chatRoomValidator.validateChatRoomCreation(userId, targetUserId);
-
         Optional<ChatRoom> existing = chatRoomRetriever.findByIdAndTargetUserId(userId, targetUserId);
         if (existing.isPresent()) {
             log.info("이미 참여중인 채팅방이므로 채팅방 그대로 반환 - chatRoomId: {}", existing.get().getId());
             return existing.get();
         }
+
+        userService.validateChatRoomCreation(userId, targetUserId);
+        chatRoomValidator.validateChatRoomCreation(userId, targetUserId);
 
         ChatRoom newRoom = ChatRoom.create();
         ChatRoom savedRoom = chatRoomSaver.save(newRoom);

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/exception/UserErrorCode.java
@@ -13,8 +13,7 @@ public enum UserErrorCode implements ErrorCode {
     INSUFFICIENT_CHAT_SLOTS(HttpStatus.BAD_REQUEST, "사용 가능한 채팅 슬롯이 존재하지 않습니다." ),
     INSUFFICIENT_CHAT_TICKETS(HttpStatus.BAD_REQUEST, "사용 가능한 채팅 티켓이 존재하지 않습니다."),
     NOT_ONBOARDING(HttpStatus.BAD_REQUEST, "온보딩을 먼저 진행해야합니다."),
-    ALREADY_ONBOARDING_USER(HttpStatus.BAD_REQUEST, "이미 온보딩을 진행한 유저입니다."),
-    INSUFFICIENT_CHAT_TICKETS(HttpStatus.BAD_REQUEST, "사용 가능한 채팅 티켓이 존재하지 않습니다.");
+    ALREADY_ONBOARDING_USER(HttpStatus.BAD_REQUEST, "이미 온보딩을 진행한 유저입니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 관련 이슈 🛠
<!-- 관련 이슈 번호를 적어주세요. -->
- closes #110 

## 작업 내용 ✏️
<!-- 작업 내용을 간단히 작성해주세요. -->
- [ ] 채팅방 생성 및 조회 검증을 기존 채팅방 반환로직 전에 실행함으로써 에러가 발생하는 문제를 해결했습니다.

## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점 등을 필요하다면 작성해주세요. -->
