### PR TITLE
Feat #102 채팅방 목록 구독/구독 해제 로직 구현

### DIFF
--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/common/constant/Constants.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/common/constant/Constants.java
@@ -1,5 +1,6 @@
 package com.lovesoongalarm.lovesoongalarm.common.constant;
 
+import java.time.Duration;
 import java.util.List;
 
 public class Constants {
@@ -25,4 +26,5 @@ public class Constants {
             "/api/auth/reissue",
             "/ws/**"
     );
+    public static final Duration SUBSCRIPTION_TTL = Duration.ofHours(24);
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/common/constant/RedisKey.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/common/constant/RedisKey.java
@@ -9,4 +9,5 @@ public class RedisKey {
     public static final String USER_GENDER_KEY = "user:gender";
     public static final String CHAT_ROOM_SUBSCRIBERS_KEY = "chatroom:subscribers:";
     public static final String USER_CHAT_SUBSCRIBERS_KEY = "user:chat:subscribers:";
+    public static final String CHAT_LIST_SUBSCRIBERS_KEY = "chatlist:subscribers:";
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/business/ChatService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/business/ChatService.java
@@ -3,8 +3,6 @@ package com.lovesoongalarm.lovesoongalarm.domain.chat.business;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.business.ChatRoomService;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.persistence.entity.ChatRoom;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.business.MessageService;
-import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.messaging.MessageSender;
-import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.session.SessionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -16,21 +14,8 @@ import org.springframework.web.socket.WebSocketSession;
 @RequiredArgsConstructor
 public class ChatService {
 
-    private final SessionService sessionService;
-    private final MessageSender messageSender;
     private final ChatRoomService chatRoomService;
     private final MessageService messageService;
-
-    public void registerSession(Long userId, String userNickname, WebSocketSession session) {
-        log.info("사용자 연결 시작 - userId: {}, sessionId: {}", userId, session.getId());
-        sessionService.addSession(userId, session);
-        messageSender.sendConnectionSuccessMessage(userId, userNickname, session);
-        log.info("사용자 연결 완료 - userId: {}, sessionId: {}", userId, session.getId());
-    }
-
-    public void removeSession(Long userId) {
-        sessionService.removeSession(userId);
-    }
 
     public void handleSubscribe(WebSocketSession session, Long chatRoomId, Long userId) {
         log.info("채팅방 구독 시작 - userId: {}, chatRoomId: {}", userId, chatRoomId);

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/ReadProcessingService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/ReadProcessingService.java
@@ -100,7 +100,7 @@ public class ReadProcessingService {
                         .isRead(lastMessage.isRead())
                         .build();
 
-                userSubscriptionService.publishUserChatUpdate(chatRoomId, partnerId, partnerUpdate);
+                userSubscriptionService.publishUserChatUpdate(partnerId, partnerUpdate);
                 log.debug("상대방에게 읽음 상태 업데이트 알림 전송 - partnerId: {}, chatRoomId: {}", partnerId, chatRoomId);
             }
 

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/business/ChatService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/business/ChatService.java
@@ -3,6 +3,7 @@ package com.lovesoongalarm.lovesoongalarm.domain.websocket.business;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.business.ChatRoomService;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.persistence.entity.ChatRoom;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.business.MessageService;
+import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.business.SubscriptionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ public class ChatService {
 
     private final ChatRoomService chatRoomService;
     private final MessageService messageService;
+    private final SubscriptionService subscriptionService;
 
     public void handleSubscribe(WebSocketSession session, Long chatRoomId, Long userId) {
         log.info("채팅방 구독 시작 - userId: {}, chatRoomId: {}", userId, chatRoomId);
@@ -27,6 +29,18 @@ public class ChatService {
         log.info("채팅방 구독 해제 시작 - userId: {}, chatRoomId: {}", userId, chatRoomId);
         chatRoomService.unsubscribeToChatRoom(session, chatRoomId, userId);
         log.info("채팅방 구독 해제 완료 - userId: {}, chatRoomId: {}", userId, chatRoomId);
+    }
+
+    public void subscribeToChatList(WebSocketSession session, Long userId) {
+        log.info("채팅방 목록 구독 시작 - userId: {}", userId);
+        subscriptionService.subscribeToChatList(session, userId);
+        log.info("채팅방 목록 구독 완료 - userId: {}", userId);
+    }
+
+    public void unsubscribeFromChatList(WebSocketSession session, Long userId) {
+        log.info("채팅방 목록 구독 해제 시작 - userId: {}", userId);
+        subscriptionService.unsubscribeFromChatList(session, userId);
+        log.info("채팅방 목록 구독 해제 완료 - userId: {}", userId);
     }
 
     @Transactional

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/business/ChatService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/business/ChatService.java
@@ -1,4 +1,4 @@
-package com.lovesoongalarm.lovesoongalarm.domain.chat.business;
+package com.lovesoongalarm.lovesoongalarm.domain.websocket.business;
 
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.business.ChatRoomService;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.persistence.entity.ChatRoom;

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/business/WebSocketConnectionService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/business/WebSocketConnectionService.java
@@ -23,7 +23,7 @@ public class WebSocketConnectionService {
         Long userId = extractUserId(session);
         String userNickname = userQueryService.getUserNickname(userId);
         sessionService.addSession(userId, session);
-        subscriptionService.subscribeToUserChatUpdates(session, userId);
+        subscriptionService.subscribeToChatBadgeUpdate(session, userId);
         messageSender.sendConnectionSuccessMessage(userId, userNickname, session);
     }
 
@@ -31,7 +31,7 @@ public class WebSocketConnectionService {
         Long userId = extractUserId(session);
         if (userId != null) {
             sessionService.removeSession(userId);
-            subscriptionService.unsubscribeFromUserChatUpdates(userId);
+            subscriptionService.unsubscribeFromChatBadgeUpdate(userId);
         }
     }
 

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/business/WebSocketMessageRouter.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/business/WebSocketMessageRouter.java
@@ -3,7 +3,7 @@ package com.lovesoongalarm.lovesoongalarm.domain.websocket.business;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lovesoongalarm.lovesoongalarm.common.exception.CustomException;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.business.ChatService;
-import com.lovesoongalarm.lovesoongalarm.domain.chat.persistence.type.EWebSocketMessageType;
+import com.lovesoongalarm.lovesoongalarm.domain.websocket.persistence.type.EWebSocketMessageType;
 import com.lovesoongalarm.lovesoongalarm.domain.websocket.dto.WebSocketMessageDTO;
 import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.messaging.MessageSender;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/business/WebSocketMessageRouter.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/business/WebSocketMessageRouter.java
@@ -29,6 +29,8 @@ public class WebSocketMessageRouter {
             switch (request.type()) {
                 case SUBSCRIBE -> handleSubscribe(session, request, userId);
                 case UNSUBSCRIBE -> handleUnsubscribe(session, request, userId);
+                case CHAT_LIST_SUBSCRIBE -> handleChatListSubscribe(session, userId);
+                case CHAT_LIST_UNSUBSCRIBE -> handleChatListUnsubscribe(session, userId);
                 case MESSAGE_SEND -> handleSendMessage(session, request, userId);
                 default -> handleUnknownMessageType(session, request.type());
             }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/business/WebSocketMessageRouter.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/business/WebSocketMessageRouter.java
@@ -78,6 +78,24 @@ public class WebSocketMessageRouter {
         }
     }
 
+    private void handleChatListSubscribe(WebSocketSession session, Long userId) {
+        try {
+            chatService.subscribeToChatList(session, userId);
+        } catch (Exception e) {
+            log.error("채팅방 목록 구독 처리 중 예외 발생 - userId: {}", userId, e);
+            messageSender.sendErrorMessage(session, "CHAT_LIST_SUBSCRIPTION_ERROR", "채팅방 목록 구독 중 오류가 발생했습니다.");
+        }
+    }
+
+    private void handleChatListUnsubscribe(WebSocketSession session, Long userId) {
+        try {
+            chatService.unsubscribeFromChatList(session, userId);
+        } catch (Exception e) {
+            log.error("채팅방 목록 구독 해제 처리 중 예외 발생 - userId: {}", userId, e);
+            messageSender.sendErrorMessage(session, "CHAT_LIST_UNSUBSCRIPTION_ERROR", "채팅방 목록 구독 해제 중 오류가 발생했습니다.");
+        }
+    }
+
     private void handleSendMessage(WebSocketSession session, WebSocketMessageDTO.Request request, Long userId) {
         try {
             chatService.handleSendMessage(request.chatRoomId(), request.content(), userId);

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/business/WebSocketMessageRouter.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/business/WebSocketMessageRouter.java
@@ -2,7 +2,6 @@ package com.lovesoongalarm.lovesoongalarm.domain.websocket.business;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lovesoongalarm.lovesoongalarm.common.exception.CustomException;
-import com.lovesoongalarm.lovesoongalarm.domain.chat.business.ChatService;
 import com.lovesoongalarm.lovesoongalarm.domain.websocket.persistence.type.EWebSocketMessageType;
 import com.lovesoongalarm.lovesoongalarm.domain.websocket.dto.WebSocketMessageDTO;
 import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.messaging.MessageSender;

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/dto/WebSocketMessageDTO.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/dto/WebSocketMessageDTO.java
@@ -1,6 +1,6 @@
 package com.lovesoongalarm.lovesoongalarm.domain.websocket.dto;
 
-import com.lovesoongalarm.lovesoongalarm.domain.chat.persistence.type.EWebSocketMessageType;
+import com.lovesoongalarm.lovesoongalarm.domain.websocket.persistence.type.EWebSocketMessageType;
 import lombok.Builder;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/dto/WebSocketMessageDTO.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/dto/WebSocketMessageDTO.java
@@ -33,6 +33,14 @@ public class WebSocketMessageDTO {
     }
 
     @Builder
+    public record ChatListSubscribeSuccess(
+            EWebSocketMessageType type,
+            String message,
+            int totalUnreadCount
+    ) {
+    }
+
+    @Builder
     public record MessageReadNotification(
             EWebSocketMessageType type,
             Long chatRoomId,
@@ -67,6 +75,16 @@ public class WebSocketMessageDTO {
             LocalDateTime timestamp,
             boolean isMyMessage,
             boolean isRead
+    ) {
+    }
+
+    @Builder
+    public record NewChatRoomNotification(
+            EWebSocketMessageType type,
+            Long chatRoomId,
+            String partnerNickname,
+            String partnerEmoji,
+            LocalDateTime createdAt
     ) {
     }
 

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/dto/WebSocketMessageDTO.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/dto/WebSocketMessageDTO.java
@@ -35,8 +35,7 @@ public class WebSocketMessageDTO {
     @Builder
     public record ChatListSubscribeSuccess(
             EWebSocketMessageType type,
-            String message,
-            int totalUnreadCount
+            String message
     ) {
     }
 

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/persistence/type/EWebSocketMessageType.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/persistence/type/EWebSocketMessageType.java
@@ -1,4 +1,4 @@
-package com.lovesoongalarm.lovesoongalarm.domain.chat.persistence.type;
+package com.lovesoongalarm.lovesoongalarm.domain.websocket.persistence.type;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/persistence/type/EWebSocketMessageType.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/persistence/type/EWebSocketMessageType.java
@@ -9,11 +9,14 @@ public enum EWebSocketMessageType {
     CONNECTION_SUCCESS("연결 완료"),
     SUBSCRIBE("채팅방 구독"),
     UNSUBSCRIBE("채팅방 구독해제"),
+    CHAT_LIST_SUBSCRIBE("채팅방 목록 구독"),
+    CHAT_LIST_UNSUBSCRIBE("채팅방 목록 구독 해제"),
     MESSAGE_SEND("메시지 송신"),
     MESSAGE_READ("메시지 읽음"),
     CHAT_MESSAGE("채팅 메시지"),
     UNREAD_BADGE_UPDATE("안 읽은 메시지 배지 업데이트"),
     CHAT_LIST_UPDATE("채팅방 목록 업데이트"),
+    NEW_CHAT_ROOM_CREATED("새 채팅방 생성"),
     MESSAGE_COUNT_LIMIT("채팅방 메시지 제한"),
     ERROR("에러");
 

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/ChatListUpdateService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/ChatListUpdateService.java
@@ -14,15 +14,12 @@ import org.springframework.stereotype.Service;
 public class ChatListUpdateService {
 
     private final UserSubscriptionService userSubscriptionService;
-    private final UnreadCountService unreadCountService;
-    private final WebSocketNotificationSender webSocketNotificationSender;
 
     public void updateAfterNewMessage(Long chatRoomId, Message message, Long partnerId) {
         log.info("새 메시지 후 채팅방 목록 업데이트 - chatRoomId: {}, partnerId: {}", chatRoomId, partnerId);
 
         try {
             updatePartnerChatList(partnerId, chatRoomId, message, false);
-            updateUnreadBadge(partnerId);
             log.info("새 메시지 후 채팅방 목록 업데이트 완료 - partnerId: {}", partnerId);
         } catch (Exception e) {
             log.error("채팅방 목록 업데이트 실패 - chatRoomId: {}, partnerId: {}",
@@ -41,11 +38,5 @@ public class ChatListUpdateService {
 
         userSubscriptionService.publishUserChatUpdate(chatRoomId, partnerId, updateEvent);
         log.debug("상대방 채팅방 목록 업데이트 전송 - partnerId: {}, chatRoomId: {}", partnerId, chatRoomId);
-    }
-
-    private void updateUnreadBadge(Long userId) {
-        int totalUnreadCount = unreadCountService.getTotalUnreadCount(userId);
-        webSocketNotificationSender.sendUnreadBadgeUpdate(userId, totalUnreadCount);
-        log.debug("안 읽은 메시지 배지 업데이트 - userId: {}, count: {}", userId, totalUnreadCount);
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/ChatListUpdateService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/ChatListUpdateService.java
@@ -19,24 +19,19 @@ public class ChatListUpdateService {
         log.info("새 메시지 후 채팅방 목록 업데이트 - chatRoomId: {}, partnerId: {}", chatRoomId, partnerId);
 
         try {
-            updatePartnerChatList(partnerId, chatRoomId, message, false);
+            UserChatUpdateDTO updateEvent = UserChatUpdateDTO.builder()
+                    .chatRoomId(chatRoomId)
+                    .lastMessageContent(message.getContent())
+                    .timestamp(message.getCreatedAt())
+                    .isMyMessage(false)
+                    .isRead(message.isRead())
+                    .build();
+
+            userSubscriptionService.publishUserChatUpdate(partnerId, updateEvent);
             log.info("새 메시지 후 채팅방 목록 업데이트 완료 - partnerId: {}", partnerId);
         } catch (Exception e) {
             log.error("채팅방 목록 업데이트 실패 - chatRoomId: {}, partnerId: {}",
                     chatRoomId, partnerId, e);
         }
-    }
-
-    private void updatePartnerChatList(Long partnerId, Long chatRoomId, Message message, boolean isMyMessage) {
-        UserChatUpdateDTO updateEvent = UserChatUpdateDTO.builder()
-                .chatRoomId(chatRoomId)
-                .lastMessageContent(message.getContent())
-                .timestamp(message.getCreatedAt())
-                .isMyMessage(isMyMessage)
-                .isRead(message.isRead())
-                .build();
-
-        userSubscriptionService.publishUserChatUpdate(chatRoomId, partnerId, updateEvent);
-        log.debug("상대방 채팅방 목록 업데이트 전송 - partnerId: {}, chatRoomId: {}", partnerId, chatRoomId);
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/ChatMessageNotificationService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/ChatMessageNotificationService.java
@@ -40,7 +40,10 @@ public class ChatMessageNotificationService {
                 readProcessingService.handleMessageReceiveReadResult(readResult);
             }
 
-            chatListUpdateService.updateAfterNewMessage(chatRoomId, message, partnerId);
+            if (redisSubscriber.isChatListSubscribed(senderId)) {
+                chatListUpdateService.updateAfterNewMessage(chatRoomId, message, partnerId);
+            }
+
             unreadBadgeUpdateService.updateUnreadBadge(partnerId);
 
             log.info("새 메시지 알림 정책 결정 완료 - partnerId: {}", partnerId);

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/ChatMessageNotificationService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/ChatMessageNotificationService.java
@@ -20,7 +20,7 @@ public class ChatMessageNotificationService {
     private final UserService userService;
     private final MessageReadService messageReadService;
     private final ReadProcessingService readProcessingService;
-
+    private final UnreadBadgeUpdateService unreadBadgeUpdateService;
     private final RedisSubscriber redisSubscriber;
 
     public void notifyNewMessage(Long chatRoomId, Message message, Long senderId) {
@@ -41,6 +41,8 @@ public class ChatMessageNotificationService {
             }
 
             chatListUpdateService.updateAfterNewMessage(chatRoomId, message, partnerId);
+            unreadBadgeUpdateService.updateUnreadBadge(partnerId);
+
             log.info("새 메시지 알림 정책 결정 완료 - partnerId: {}", partnerId);
         } catch (Exception e) {
             log.error("메시지 알림 정책 결정 중 오류 - chatRoomId: {}, messageId: {}",

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/ChatMessageNotificationService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/ChatMessageNotificationService.java
@@ -5,7 +5,7 @@ import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.busine
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.persistence.entity.Message;
 import com.lovesoongalarm.lovesoongalarm.domain.user.business.UserService;
 import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.User;
-import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement.RedisSubscriber;
+import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.business.RedisSubscriber;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/ChatMessageNotificationService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/ChatMessageNotificationService.java
@@ -40,7 +40,7 @@ public class ChatMessageNotificationService {
                 readProcessingService.handleMessageReceiveReadResult(readResult);
             }
 
-            if (redisSubscriber.isChatListSubscribed(senderId)) {
+            if (redisSubscriber.isChatListSubscribed(partnerId)) {
                 chatListUpdateService.updateAfterNewMessage(chatRoomId, message, partnerId);
             }
 

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/ChatMessageNotificationService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/ChatMessageNotificationService.java
@@ -38,9 +38,7 @@ public class ChatMessageNotificationService {
                 MessageReadService.ReadResult readResult =
                         messageReadService.markSingleMessageAsRead(message.getId(), chatRoomId, partnerId);
                 readProcessingService.handleMessageReceiveReadResult(readResult);
-            }
-
-            if (redisSubscriber.isChatListSubscribed(partnerId)) {
+            } else if (redisSubscriber.isChatListSubscribed(partnerId)) {
                 chatListUpdateService.updateAfterNewMessage(chatRoomId, message, partnerId);
             }
 

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/MessageSender.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/MessageSender.java
@@ -1,7 +1,7 @@
 package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.messaging;
 
 import com.lovesoongalarm.lovesoongalarm.domain.websocket.dto.WebSocketMessageDTO;
-import com.lovesoongalarm.lovesoongalarm.domain.chat.persistence.type.EWebSocketMessageType;
+import com.lovesoongalarm.lovesoongalarm.domain.websocket.persistence.type.EWebSocketMessageType;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.application.dto.UserChatUpdateDTO;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.implement.MessageTransmitter;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.persistence.entity.Message;

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/MessageSender.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/MessageSender.java
@@ -66,6 +66,36 @@ public class MessageSender {
         messageTransmitter.sendMessage(session, unsubscribeSuccess);
     }
 
+    public void sendChatListSubscribeSuccessMessage(WebSocketSession session) {
+        WebSocketMessageDTO.ChatListSubscribeSuccess subscribeSuccess = WebSocketMessageDTO.ChatListSubscribeSuccess.builder()
+                .type(EWebSocketMessageType.CHAT_LIST_SUBSCRIBE)
+                .message("채팅방 목록 구독에 성공했습니다.")
+                .build();
+
+        messageTransmitter.sendMessage(session, subscribeSuccess);
+    }
+
+    public void sendChatListUnsubscribeSuccessMessage(WebSocketSession session) {
+        WebSocketMessageDTO.ChatListSubscribeSuccess unsubscribeSuccess = WebSocketMessageDTO.ChatListSubscribeSuccess.builder()
+                .type(EWebSocketMessageType.CHAT_LIST_UNSUBSCRIBE)
+                .message("채팅방 목록 구독 해제에 성공했습니다.")
+                .build();
+
+        messageTransmitter.sendMessage(session, unsubscribeSuccess);
+    }
+
+    public void sendNewChatRoomNotification(WebSocketSession session, Long chatRoomId, String partnerNickname, String partnerEmoji) {
+        WebSocketMessageDTO.NewChatRoomNotification notification = WebSocketMessageDTO.NewChatRoomNotification.builder()
+                .type(EWebSocketMessageType.NEW_CHAT_ROOM_CREATED)
+                .chatRoomId(chatRoomId)
+                .partnerNickname(partnerNickname)
+                .partnerEmoji(partnerEmoji)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        messageTransmitter.sendMessage(session, notification);
+    }
+
     public void sendReadMessage(WebSocketSession session, Long chatRoomId, Long readerId) {
         WebSocketMessageDTO.MessageReadNotification messageReadNotification = WebSocketMessageDTO.MessageReadNotification.builder()
                 .type(EWebSocketMessageType.MESSAGE_READ)

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/UnreadBadgeUpdateService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/UnreadBadgeUpdateService.java
@@ -1,0 +1,21 @@
+package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.messaging;
+
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.business.UnreadCountService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UnreadBadgeUpdateService {
+
+    private final UnreadCountService unreadCountService;
+    private final WebSocketNotificationSender webSocketNotificationSender;
+
+    public void updateUnreadBadge(Long userId) {
+        int totalUnreadCount = unreadCountService.getTotalUnreadCount(userId);
+        webSocketNotificationSender.sendUnreadBadgeUpdate(userId, totalUnreadCount);
+        log.debug("안 읽은 메시지 배지 업데이트 - userId: {}, count: {}", userId, totalUnreadCount);
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
@@ -51,7 +51,7 @@ public class RedisSubscriber {
         redisChatListSaver.subscribeToChatList(userId);
     }
 
-    public void unsubscribeToChatList(Long userId) {
+    public void unsubscribeFromChatList(Long userId) {
         redisChatListRemover.unsubscribeFromChatList(userId);
     }
 

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
@@ -5,6 +5,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import static com.lovesoongalarm.lovesoongalarm.common.constant.Constants.SUBSCRIPTION_TTL;
+import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.CHAT_LIST_SUBSCRIBERS_KEY;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -16,6 +19,9 @@ public class RedisSubscriber {
     private final RedisUserChatSaver redisUserChatSaver;
     private final RedisUserChatRemover redisUserChatRemover;
     private final RedisUserChatRetriever redisUserChatRetriever;
+    private final RedisChatListSaver redisChatListSaver;
+    private final RedisChatListRemover redisChatListRemover;
+    private final RedisChatListRetriever redisChatListRetriever;
 
     public void addSubscriber(Long chatRoomId, Long userId) {
         redisChatRoomSaver.addSubscriber(chatRoomId, userId);
@@ -39,5 +45,17 @@ public class RedisSubscriber {
 
     public boolean isUserSubscribed(Long userId) {
         return redisUserChatRetriever.isUserSubscribed(userId);
+    }
+
+    public void subscribeToChatList(Long userId) {
+        redisChatListSaver.subscribeToChatList(userId);
+    }
+
+    public void unsubscribeToChatList(Long userId) {
+        redisChatListRemover.unsubscribeFromChatList(userId);
+    }
+
+    public boolean isChatListSubscribed(Long userId) {
+        return redisChatListRetriever.isChatListSubscribed(userId);
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
@@ -1,4 +1,4 @@
-package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement;
+package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.business;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
@@ -3,23 +3,19 @@ package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.busi
 import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
-
-import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.USER_CHAT_SUBSCRIBERS_KEY;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class RedisSubscriber {
 
-    private final StringRedisTemplate stringRedisTemplate;
-
     private final RedisChatRoomSaver redisChatRoomSaver;
     private final RedisChatRoomRemover redisChatRoomRemover;
     private final RedisChatRoomRetriever redisChatRoomRetriever;
     private final RedisUserChatSaver redisUserChatSaver;
     private final RedisUserChatRemover redisUserChatRemover;
+    private final RedisUserChatRetriever redisUserChatRetriever;
 
     public void addSubscriber(Long chatRoomId, Long userId) {
         redisChatRoomSaver.addSubscriber(chatRoomId, userId);
@@ -42,19 +38,6 @@ public class RedisSubscriber {
     }
 
     public boolean isUserSubscribed(Long userId) {
-        try {
-            String subscribersKey = USER_CHAT_SUBSCRIBERS_KEY + userId;
-            Boolean isMember = stringRedisTemplate.opsForSet().isMember(subscribersKey, userId.toString());
-
-            boolean isSubscribed = Boolean.TRUE.equals(isMember);
-            if (isSubscribed) {
-                stringRedisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
-            }
-            log.debug("사용자 구독 상태 확인 - userId: {}, isSubscribed: {}", userId, isSubscribed);
-            return isSubscribed;
-        } catch (Exception e) {
-            log.error("사용자 구독 상태 체크 실패 - userId: {}", userId, e);
-            return false;
-        }
+        return redisUserChatRetriever.isUserSubscribed(userId);
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
@@ -5,9 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import static com.lovesoongalarm.lovesoongalarm.common.constant.Constants.SUBSCRIPTION_TTL;
-import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.CHAT_LIST_SUBSCRIBERS_KEY;
-
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -35,12 +32,12 @@ public class RedisSubscriber {
         return redisChatRoomRetriever.isUserSubscribed(chatRoomId, userId);
     }
 
-    public void subscribeToUserChatUpdates(Long userId) {
-        redisUserChatSaver.subscribeToUserChatUpdates(userId);
+    public void subscribeToChatBadgeUpdate(Long userId) {
+        redisUserChatSaver.subscribeToChatBadgeUpdate(userId);
     }
 
-    public void unsubscribeFromUserChatUpdates(Long userId) {
-        redisUserChatRemover.unsubscribeFromUserChatUpdates(userId);
+    public void unsubscribeFromChatBadgeUpdate(Long userId) {
+        redisUserChatRemover.unsubscribeFromChatBadgeUpdate(userId);
     }
 
     public boolean isUserSubscribed(Long userId) {

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
@@ -3,6 +3,7 @@ package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.busi
 import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement.RedisChatRoomRemover;
 import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement.RedisChatRoomRetriever;
 import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement.RedisChatRoomSaver;
+import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement.RedisUserChatSaver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -20,6 +21,7 @@ public class RedisSubscriber {
     private final RedisChatRoomSaver redisChatRoomSaver;
     private final RedisChatRoomRemover redisChatRoomRemover;
     private final RedisChatRoomRetriever redisChatRoomRetriever;
+    private final RedisUserChatSaver redisUserChatSaver;
 
     public void addSubscriber(Long chatRoomId, Long userId) {
         redisChatRoomSaver.addSubscriber(chatRoomId, userId);
@@ -34,16 +36,7 @@ public class RedisSubscriber {
     }
 
     public void subscribeToUserChatUpdates(Long userId) {
-        try {
-            String subscribersKey = USER_CHAT_SUBSCRIBERS_KEY + userId;
-
-            stringRedisTemplate.opsForSet().add(subscribersKey, userId.toString());
-            stringRedisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
-
-            log.info("사용자 채팅 업데이트 구독 시작 - userId: {}", userId);
-        } catch (Exception e) {
-            log.error("사용자 채팅 업데이트 구독 실패 - userId: {}", userId, e);
-        }
+        redisUserChatSaver.subscribeToUserChatUpdates(userId);
     }
 
     public void unsubscribeFromUserChatUpdates(Long userId) {

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
@@ -1,5 +1,6 @@
 package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.business;
 
+import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement.RedisChatRoomSaver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -17,19 +18,12 @@ public class RedisSubscriber {
 
     private final StringRedisTemplate stringRedisTemplate;
 
+    private final RedisChatRoomSaver redisChatRoomSaver;
+
     private static final Duration SUBSCRIPTION_TTL = Duration.ofHours(24);
 
     public void addSubscriber(Long chatRoomId, Long userId) {
-        try {
-            String subscribersKey = CHAT_ROOM_SUBSCRIBERS_KEY + chatRoomId;
-            stringRedisTemplate.opsForSet().add(subscribersKey, userId.toString());
-            stringRedisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
-
-            log.info("Redis 구독 추가 - 채팅방: {}, 유저: {}", chatRoomId, userId);
-
-        } catch (Exception e) {
-            log.error("Redis 구독 추가 실패 - 채팅방: {}, 유저: {}", chatRoomId, userId, e);
-        }
+        redisChatRoomSaver.addSubscriber(chatRoomId, userId);
     }
 
     public void removeSubscriber(Long chatRoomId, Long userId) {

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
@@ -1,5 +1,6 @@
 package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.business;
 
+import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement.RedisChatRoomRemover;
 import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement.RedisChatRoomSaver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,34 +17,19 @@ import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.USER_CH
 @Slf4j
 public class RedisSubscriber {
 
+    private static final Duration SUBSCRIPTION_TTL = Duration.ofHours(24);
+
     private final StringRedisTemplate stringRedisTemplate;
 
     private final RedisChatRoomSaver redisChatRoomSaver;
-
-    private static final Duration SUBSCRIPTION_TTL = Duration.ofHours(24);
+    private final RedisChatRoomRemover redisChatRoomRemover;
 
     public void addSubscriber(Long chatRoomId, Long userId) {
         redisChatRoomSaver.addSubscriber(chatRoomId, userId);
     }
 
     public void removeSubscriber(Long chatRoomId, Long userId) {
-        try {
-            String subscribersKey = CHAT_ROOM_SUBSCRIBERS_KEY + chatRoomId;
-            stringRedisTemplate.opsForSet().remove(subscribersKey, userId.toString());
-
-            Long remainingCount = stringRedisTemplate.opsForSet().size(subscribersKey);
-            if (remainingCount != null && remainingCount == 0) {
-                stringRedisTemplate.delete(subscribersKey);
-                log.debug("빈 구독 키 삭제 - 채팅방: {}", chatRoomId);
-            } else {
-                stringRedisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
-            }
-
-            log.info("Redis 구독 제거 - 채팅방: {}, 멤버: {}", chatRoomId, userId);
-
-        } catch (Exception e) {
-            log.error("Redis 구독 제거 실패 - 채팅방: {}, 멤버: {}", chatRoomId, userId, e);
-        }
+        redisChatRoomRemover.removeSubscriber(chatRoomId, userId);
     }
 
     public boolean isUserSubscribed(Long chatRoomId, Long userId) {

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
@@ -1,15 +1,13 @@
 package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.business;
 
 import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement.RedisChatRoomRemover;
+import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement.RedisChatRoomRetriever;
 import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement.RedisChatRoomSaver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.time.Duration;
-
-import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.CHAT_ROOM_SUBSCRIBERS_KEY;
 import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.USER_CHAT_SUBSCRIBERS_KEY;
 
 @Service
@@ -17,12 +15,11 @@ import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.USER_CH
 @Slf4j
 public class RedisSubscriber {
 
-    private static final Duration SUBSCRIPTION_TTL = Duration.ofHours(24);
-
     private final StringRedisTemplate stringRedisTemplate;
 
     private final RedisChatRoomSaver redisChatRoomSaver;
     private final RedisChatRoomRemover redisChatRoomRemover;
+    private final RedisChatRoomRetriever redisChatRoomRetriever;
 
     public void addSubscriber(Long chatRoomId, Long userId) {
         redisChatRoomSaver.addSubscriber(chatRoomId, userId);
@@ -33,20 +30,7 @@ public class RedisSubscriber {
     }
 
     public boolean isUserSubscribed(Long chatRoomId, Long userId) {
-        try {
-            String subscribersKey = CHAT_ROOM_SUBSCRIBERS_KEY + chatRoomId;
-            Boolean isMember = stringRedisTemplate.opsForSet().isMember(subscribersKey, userId.toString());
-
-            boolean isSubscribed = Boolean.TRUE.equals(isMember);
-            if (isSubscribed) {
-                stringRedisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
-            }
-            log.debug("채팅방 구독 상태 확인 - chatRoomId: {}, userId: {}, isSubscribed: {}", chatRoomId, userId, isSubscribed);
-            return isSubscribed;
-        } catch (Exception e) {
-            log.error("Redis 구독 상태 체크 실패 - 채팅방: {}, 유저: {}", chatRoomId, userId, e);
-            return false;
-        }
+        redisChatRoomRetriever.isUserSubscribed(chatRoomId, userId);
     }
 
     public void subscribeToUserChatUpdates(Long userId) {

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/RedisSubscriber.java
@@ -30,7 +30,7 @@ public class RedisSubscriber {
     }
 
     public boolean isUserSubscribed(Long chatRoomId, Long userId) {
-        redisChatRoomRetriever.isUserSubscribed(chatRoomId, userId);
+        return redisChatRoomRetriever.isUserSubscribed(chatRoomId, userId);
     }
 
     public void subscribeToUserChatUpdates(Long userId) {

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/SubscriptionService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/SubscriptionService.java
@@ -35,13 +35,13 @@ public class SubscriptionService {
     }
 
     public void subscribeToChatBadgeUpdate(WebSocketSession session, Long userId){
-        redisSubscriber.subscribeToUserChatUpdates(userId);
+        redisSubscriber.subscribeToChatBadgeUpdate(userId);
         int totalUnreadCount = unreadCountService.getTotalUnreadCount(userId);
         messageSender.sendUnreadBadgeUpdate(session, totalUnreadCount);
     }
 
     public void unsubscribeFromChatBadgeUpdate(Long userId){
-        redisSubscriber.unsubscribeFromUserChatUpdates(userId);
+        redisSubscriber.unsubscribeFromChatBadgeUpdate(userId);
     }
 
     public void subscribeToChatList(WebSocketSession session, Long userId) {

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/SubscriptionService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/SubscriptionService.java
@@ -4,7 +4,6 @@ import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.busine
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.business.ReadProcessingService;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.business.UnreadCountService;
 import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.messaging.MessageSender;
-import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement.RedisSubscriber;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/SubscriptionService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/SubscriptionService.java
@@ -34,14 +34,14 @@ public class SubscriptionService {
         messageSender.sendUnsubscribeSuccessMessage(session, chatRoomId);
     }
 
-    public void subscribeToUserChatUpdates(WebSocketSession session, Long userId){
+    public void subscribeToChatBadgeUpdate(WebSocketSession session, Long userId){
         redisSubscriber.subscribeToUserChatUpdates(userId);
 
         int totalUnreadCount = unreadCountService.getTotalUnreadCount(userId);
         messageSender.sendUnreadBadgeUpdate(session, totalUnreadCount);
     }
 
-    public void unsubscribeFromUserChatUpdates(Long userId){
+    public void unsubscribeFromChatBadgeUpdate(Long userId){
         redisSubscriber.unsubscribeFromUserChatUpdates(userId);
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/SubscriptionService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/SubscriptionService.java
@@ -45,16 +45,12 @@ public class SubscriptionService {
     }
 
     public void subscribeToChatList(WebSocketSession session, Long userId) {
-        log.info("채팅방 목록 구독 시작 - userId: {}", userId);
         redisSubscriber.subscribeToChatList(userId);
         messageSender.sendChatListSubscribeSuccessMessage(session);
-        log.info("채팅방 목록 구독 완료 - userId: {}", userId);
     }
 
     public void unsubscribeFromChatList(WebSocketSession session, Long userId) {
-        log.info("채팅방 목록 구독 해제 시작 - userId: {}", userId);
         redisSubscriber.unsubscribeFromChatList(userId);
         messageSender.sendChatListUnsubscribeSuccessMessage(session);
-        log.info("채팅방 목록 구독 해제 완료 - userId: {}", userId);
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/SubscriptionService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/SubscriptionService.java
@@ -36,12 +36,25 @@ public class SubscriptionService {
 
     public void subscribeToChatBadgeUpdate(WebSocketSession session, Long userId){
         redisSubscriber.subscribeToUserChatUpdates(userId);
-
         int totalUnreadCount = unreadCountService.getTotalUnreadCount(userId);
         messageSender.sendUnreadBadgeUpdate(session, totalUnreadCount);
     }
 
     public void unsubscribeFromChatBadgeUpdate(Long userId){
         redisSubscriber.unsubscribeFromUserChatUpdates(userId);
+    }
+
+    public void subscribeToChatList(WebSocketSession session, Long userId) {
+        log.info("채팅방 목록 구독 시작 - userId: {}", userId);
+        redisSubscriber.subscribeToChatList(userId);
+        messageSender.sendChatListSubscribeSuccessMessage(session);
+        log.info("채팅방 목록 구독 완료 - userId: {}", userId);
+    }
+
+    public void unsubscribeFromChatList(WebSocketSession session, Long userId) {
+        log.info("채팅방 목록 구독 해제 시작 - userId: {}", userId);
+        redisSubscriber.unsubscribeFromChatList(userId);
+        messageSender.sendChatListUnsubscribeSuccessMessage(session);
+        log.info("채팅방 목록 구독 해제 완료 - userId: {}", userId);
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/UserSubscriptionService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/UserSubscriptionService.java
@@ -14,13 +14,13 @@ import org.springframework.web.socket.WebSocketSession;
 public class UserSubscriptionService {
 
     private final RedisSubscriber redisSubscriber;
-
     private final SessionService sessionService;
     private final MessageSender messageSender;
 
     public void publishUnreadBadgeUpdate(Long userId, int totalUnreadCount) {
         try {
             if (!redisSubscriber.isUserSubscribed(userId)) {
+                log.debug("배지 업데이트 구독하지 않은 사용자 - userId: {}", userId);
                 return;
             }
 
@@ -40,7 +40,7 @@ public class UserSubscriptionService {
 
     public void publishUserChatUpdate(Long chatRoomId, Long userId, UserChatUpdateDTO updateEvent) {
         try {
-            if (!redisSubscriber.isUserSubscribed(userId)) {
+            if (!redisSubscriber.isChatListSubscribed(userId)) {
                 log.debug("목록을 구독하지 않은 사용자에게는 업데이트를 보내지 않음 - userId: {}", userId);
                 return;
             }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/UserSubscriptionService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/UserSubscriptionService.java
@@ -63,4 +63,25 @@ public class UserSubscriptionService {
             log.error("사용자 채팅 업데이트 발행 실패 - userId: {}", userId, e);
         }
     }
+
+    public void publishNewChatRoomNotification(Long userId, Long chatRoomId, String partnerNickname, String partnerEmoji) {
+        try {
+            if (!redisSubscriber.isChatListSubscribed(userId)) {
+                log.debug("채팅방 목록을 구독하지 않은 사용자에게는 새 채팅방 알림을 보내지 않음 - userId: {}", userId);
+                return;
+            }
+
+            WebSocketSession session = sessionService.getSession(userId);
+            if (session == null || !session.isOpen()) {
+                log.debug("사용자 세션이 없거나 닫혀있음 - userId: {}", userId);
+                return;
+            }
+
+            messageSender.sendNewChatRoomNotification(session, chatRoomId, partnerNickname, partnerEmoji);
+            log.info("새 채팅방 알림 전송 완료 - userId: {}, chatRoomId: {}, partner: {}", userId, chatRoomId, partnerNickname);
+
+        } catch (Exception e) {
+            log.error("새 채팅방 알림 발행 실패 - userId: {}, chatRoomId: {}", userId, chatRoomId, e);
+        }
+    }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/UserSubscriptionService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/UserSubscriptionService.java
@@ -38,18 +38,8 @@ public class UserSubscriptionService {
         }
     }
 
-    public void publishUserChatUpdate(Long chatRoomId, Long userId, UserChatUpdateDTO updateEvent) {
+    public void publishUserChatUpdate(Long userId, UserChatUpdateDTO updateEvent) {
         try {
-            if (!redisSubscriber.isChatListSubscribed(userId)) {
-                log.debug("목록을 구독하지 않은 사용자에게는 업데이트를 보내지 않음 - userId: {}", userId);
-                return;
-            }
-
-            if (redisSubscriber.isUserSubscribed(chatRoomId, userId)) {
-                log.debug("채팅방을 구독중인 사용자에게는 업데이트를 보내지 않음 - userId: {}", userId);
-                return;
-            }
-
             WebSocketSession session = sessionService.getSession(userId);
             if (session == null || !session.isOpen()) {
                 log.debug("사용자 세션이 없거나 닫혀있음 - userId: {}", userId);

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/UserSubscriptionService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/business/UserSubscriptionService.java
@@ -3,7 +3,6 @@ package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.busi
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.application.dto.UserChatUpdateDTO;
 import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.messaging.MessageSender;
 import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.session.SessionService;
-import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement.RedisSubscriber;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatListRemover.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatListRemover.java
@@ -1,0 +1,36 @@
+package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import static com.lovesoongalarm.lovesoongalarm.common.constant.Constants.SUBSCRIPTION_TTL;
+import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.CHAT_LIST_SUBSCRIBERS_KEY;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedisChatListRemover {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public void unsubscribeFromChatList(Long userId) {
+        try {
+            String subscribersKey = CHAT_LIST_SUBSCRIBERS_KEY + userId;
+            stringRedisTemplate.opsForSet().remove(subscribersKey, userId.toString());
+
+            Long remainingCount = stringRedisTemplate.opsForSet().size(subscribersKey);
+            if (remainingCount != null && remainingCount == 0) {
+                stringRedisTemplate.delete(subscribersKey);
+                log.debug("빈 채팅방 목록 구독 키 삭제 - userId: {}", userId);
+            } else {
+                stringRedisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
+            }
+
+            log.info("채팅방 목록 구독 해제 - userId: {}", userId);
+        } catch (Exception e) {
+            log.error("채팅방 목록 구독 해제 실패 - userId: {}", userId, e);
+        }
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatListRetriever.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatListRetriever.java
@@ -1,0 +1,34 @@
+package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import static com.lovesoongalarm.lovesoongalarm.common.constant.Constants.SUBSCRIPTION_TTL;
+import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.CHAT_LIST_SUBSCRIBERS_KEY;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedisChatListRetriever {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public boolean isChatListSubscribed(Long userId) {
+        try {
+            String subscribersKey = CHAT_LIST_SUBSCRIBERS_KEY + userId;
+            Boolean isMember = stringRedisTemplate.opsForSet().isMember(subscribersKey, userId.toString());
+
+            boolean isSubscribed = Boolean.TRUE.equals(isMember);
+            if (isSubscribed) {
+                stringRedisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
+            }
+            log.debug("채팅방 목록 구독 상태 확인 - userId: {}, isSubscribed: {}", userId, isSubscribed);
+            return isSubscribed;
+        } catch (Exception e) {
+            log.error("채팅방 목록 구독 상태 체크 실패 - userId: {}", userId, e);
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatListSaver.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatListSaver.java
@@ -1,0 +1,31 @@
+package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import static com.lovesoongalarm.lovesoongalarm.common.constant.Constants.SUBSCRIPTION_TTL;
+import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.CHAT_LIST_SUBSCRIBERS_KEY;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedisChatListSaver {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public void subscribeToChatList(Long userId) {
+        try {
+            String subscribersKey = CHAT_LIST_SUBSCRIBERS_KEY + userId;
+            stringRedisTemplate.opsForSet().add(subscribersKey, userId.toString());
+            stringRedisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
+
+            log.info("채팅방 목록 구독 시작 - userId: {}", userId);
+        } catch (Exception e) {
+            log.error("채팅방 목록 구독 실패 - userId: {}", userId, e);
+        }
+    }
+
+
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatListSaver.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatListSaver.java
@@ -20,8 +20,6 @@ public class RedisChatListSaver {
             String subscribersKey = CHAT_LIST_SUBSCRIBERS_KEY + userId;
             stringRedisTemplate.opsForSet().add(subscribersKey, userId.toString());
             stringRedisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
-
-            log.info("채팅방 목록 구독 시작 - userId: {}", userId);
         } catch (Exception e) {
             log.error("채팅방 목록 구독 실패 - userId: {}", userId, e);
         }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatRoomRemover.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatRoomRemover.java
@@ -1,0 +1,40 @@
+package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.CHAT_ROOM_SUBSCRIBERS_KEY;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RedisChatRoomRemover {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    private static final Duration SUBSCRIPTION_TTL = Duration.ofHours(24);
+
+    public void removeSubscriber(Long chatRoomId, Long userId) {
+        try {
+            String subscribersKey = CHAT_ROOM_SUBSCRIBERS_KEY + chatRoomId;
+            stringRedisTemplate.opsForSet().remove(subscribersKey, userId.toString());
+
+            Long remainingCount = stringRedisTemplate.opsForSet().size(subscribersKey);
+            if (remainingCount != null && remainingCount == 0) {
+                stringRedisTemplate.delete(subscribersKey);
+                log.debug("빈 구독 키 삭제 - 채팅방: {}", chatRoomId);
+            } else {
+                stringRedisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
+            }
+
+            log.info("Redis 구독 제거 - 채팅방: {}, 멤버: {}", chatRoomId, userId);
+
+        } catch (Exception e) {
+            log.error("Redis 구독 제거 실패 - 채팅방: {}, 멤버: {}", chatRoomId, userId, e);
+        }
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatRoomRemover.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatRoomRemover.java
@@ -3,12 +3,12 @@ package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.impl
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 import static com.lovesoongalarm.lovesoongalarm.common.constant.Constants.SUBSCRIPTION_TTL;
 import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.CHAT_ROOM_SUBSCRIBERS_KEY;
 
-@Service
+@Component
 @RequiredArgsConstructor
 @Slf4j
 public class RedisChatRoomRemover {

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatRoomRemover.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatRoomRemover.java
@@ -5,8 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.time.Duration;
-
+import static com.lovesoongalarm.lovesoongalarm.common.constant.Constants.SUBSCRIPTION_TTL;
 import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.CHAT_ROOM_SUBSCRIBERS_KEY;
 
 @Service
@@ -15,8 +14,6 @@ import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.CHAT_RO
 public class RedisChatRoomRemover {
 
     private final StringRedisTemplate stringRedisTemplate;
-
-    private static final Duration SUBSCRIPTION_TTL = Duration.ofHours(24);
 
     public void removeSubscriber(Long chatRoomId, Long userId) {
         try {

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatRoomRetriever.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatRoomRetriever.java
@@ -1,0 +1,36 @@
+package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+import static com.lovesoongalarm.lovesoongalarm.common.constant.Constants.SUBSCRIPTION_TTL;
+import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.CHAT_ROOM_SUBSCRIBERS_KEY;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RedisChatRoomRetriever {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public boolean isUserSubscribed(Long chatRoomId, Long userId) {
+        try {
+            String subscribersKey = CHAT_ROOM_SUBSCRIBERS_KEY + chatRoomId;
+            Boolean isMember = stringRedisTemplate.opsForSet().isMember(subscribersKey, userId.toString());
+
+            boolean isSubscribed = Boolean.TRUE.equals(isMember);
+            if (isSubscribed) {
+                stringRedisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
+            }
+            log.debug("채팅방 구독 상태 확인 - chatRoomId: {}, userId: {}, isSubscribed: {}", chatRoomId, userId, isSubscribed);
+            return isSubscribed;
+        } catch (Exception e) {
+            log.error("Redis 구독 상태 체크 실패 - 채팅방: {}, 유저: {}", chatRoomId, userId, e);
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatRoomRetriever.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatRoomRetriever.java
@@ -3,14 +3,12 @@ package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.impl
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.stereotype.Service;
-
-import java.time.Duration;
+import org.springframework.stereotype.Component;
 
 import static com.lovesoongalarm.lovesoongalarm.common.constant.Constants.SUBSCRIPTION_TTL;
 import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.CHAT_ROOM_SUBSCRIBERS_KEY;
 
-@Service
+@Component
 @RequiredArgsConstructor
 @Slf4j
 public class RedisChatRoomRetriever {

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatRoomSaver.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatRoomSaver.java
@@ -1,0 +1,31 @@
+package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.CHAT_ROOM_SUBSCRIBERS_KEY;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RedisChatRoomSaver {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    private static final Duration SUBSCRIPTION_TTL = Duration.ofHours(24);
+
+    public void addSubscriber(Long chatRoomId, Long userId) {
+        try {
+            String subscribersKey = CHAT_ROOM_SUBSCRIBERS_KEY + chatRoomId;
+            stringRedisTemplate.opsForSet().add(subscribersKey, userId.toString());
+            stringRedisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
+            log.info("Redis 구독 추가 - 채팅방: {}, 유저: {}", chatRoomId, userId);
+        } catch (Exception e) {
+            log.error("Redis 구독 추가 실패 - 채팅방: {}, 유저: {}", chatRoomId, userId, e);
+        }
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatRoomSaver.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatRoomSaver.java
@@ -5,8 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.time.Duration;
-
+import static com.lovesoongalarm.lovesoongalarm.common.constant.Constants.SUBSCRIPTION_TTL;
 import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.CHAT_ROOM_SUBSCRIBERS_KEY;
 
 @Service
@@ -15,8 +14,6 @@ import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.CHAT_RO
 public class RedisChatRoomSaver {
 
     private final StringRedisTemplate stringRedisTemplate;
-
-    private static final Duration SUBSCRIPTION_TTL = Duration.ofHours(24);
 
     public void addSubscriber(Long chatRoomId, Long userId) {
         try {

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatRoomSaver.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisChatRoomSaver.java
@@ -3,12 +3,12 @@ package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.impl
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 import static com.lovesoongalarm.lovesoongalarm.common.constant.Constants.SUBSCRIPTION_TTL;
 import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.CHAT_ROOM_SUBSCRIBERS_KEY;
 
-@Service
+@Component
 @RequiredArgsConstructor
 @Slf4j
 public class RedisChatRoomSaver {

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisUserChatRemover.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisUserChatRemover.java
@@ -15,7 +15,7 @@ public class RedisUserChatRemover {
 
     private final StringRedisTemplate stringRedisTemplate;
 
-    public void unsubscribeFromUserChatUpdates(Long userId) {
+    public void unsubscribeFromChatBadgeUpdate(Long userId) {
         try {
             String subscribersKey = USER_CHAT_SUBSCRIBERS_KEY + userId;
             stringRedisTemplate.opsForSet().remove(subscribersKey, userId.toString());

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisUserChatRemover.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisUserChatRemover.java
@@ -3,12 +3,12 @@ package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.impl
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 import static com.lovesoongalarm.lovesoongalarm.common.constant.Constants.SUBSCRIPTION_TTL;
 import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.USER_CHAT_SUBSCRIBERS_KEY;
 
-@Service
+@Component
 @RequiredArgsConstructor
 @Slf4j
 public class RedisUserChatRemover {

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisUserChatRemover.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisUserChatRemover.java
@@ -1,0 +1,36 @@
+package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import static com.lovesoongalarm.lovesoongalarm.common.constant.Constants.SUBSCRIPTION_TTL;
+import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.USER_CHAT_SUBSCRIBERS_KEY;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RedisUserChatRemover {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public void unsubscribeFromUserChatUpdates(Long userId) {
+        try {
+            String subscribersKey = USER_CHAT_SUBSCRIBERS_KEY + userId;
+            stringRedisTemplate.opsForSet().remove(subscribersKey, userId.toString());
+
+            Long remainingCount = stringRedisTemplate.opsForSet().size(subscribersKey);
+            if (remainingCount != null && remainingCount == 0) {
+                stringRedisTemplate.delete(subscribersKey);
+                log.debug("빈 구독 키 삭제 - userId: {}", userId);
+            } else {
+                stringRedisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
+            }
+
+            log.info("사용자 채팅 업데이트 구독 해제 - userId: {}", userId);
+        } catch (Exception e) {
+            log.error("사용자 채팅 업데이트 구독 해제 실패 - userId: {}", userId, e);
+        }
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisUserChatRetriever.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisUserChatRetriever.java
@@ -1,0 +1,34 @@
+package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import static com.lovesoongalarm.lovesoongalarm.common.constant.Constants.SUBSCRIPTION_TTL;
+import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.USER_CHAT_SUBSCRIBERS_KEY;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RedisUserChatRetriever {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public boolean isUserSubscribed(Long userId) {
+        try {
+            String subscribersKey = USER_CHAT_SUBSCRIBERS_KEY + userId;
+            Boolean isMember = stringRedisTemplate.opsForSet().isMember(subscribersKey, userId.toString());
+
+            boolean isSubscribed = Boolean.TRUE.equals(isMember);
+            if (isSubscribed) {
+                stringRedisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
+            }
+            log.debug("사용자 구독 상태 확인 - userId: {}, isSubscribed: {}", userId, isSubscribed);
+            return isSubscribed;
+        } catch (Exception e) {
+            log.error("사용자 구독 상태 체크 실패 - userId: {}", userId, e);
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisUserChatRetriever.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisUserChatRetriever.java
@@ -3,12 +3,12 @@ package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.impl
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 import static com.lovesoongalarm.lovesoongalarm.common.constant.Constants.SUBSCRIPTION_TTL;
 import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.USER_CHAT_SUBSCRIBERS_KEY;
 
-@Service
+@Component
 @RequiredArgsConstructor
 @Slf4j
 public class RedisUserChatRetriever {

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisUserChatSaver.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisUserChatSaver.java
@@ -3,12 +3,12 @@ package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.impl
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 import static com.lovesoongalarm.lovesoongalarm.common.constant.Constants.SUBSCRIPTION_TTL;
 import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.USER_CHAT_SUBSCRIBERS_KEY;
 
-@Service
+@Component
 @RequiredArgsConstructor
 @Slf4j
 public class RedisUserChatSaver {

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisUserChatSaver.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisUserChatSaver.java
@@ -15,7 +15,7 @@ public class RedisUserChatSaver {
 
     private final StringRedisTemplate stringRedisTemplate;
 
-    public void subscribeToUserChatUpdates(Long userId) {
+    public void subscribeToChatBadgeUpdate(Long userId) {
         try {
             String subscribersKey = USER_CHAT_SUBSCRIBERS_KEY + userId;
 

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisUserChatSaver.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/subscription/implement/RedisUserChatSaver.java
@@ -1,0 +1,30 @@
+package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.subscription.implement;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import static com.lovesoongalarm.lovesoongalarm.common.constant.Constants.SUBSCRIPTION_TTL;
+import static com.lovesoongalarm.lovesoongalarm.common.constant.RedisKey.USER_CHAT_SUBSCRIBERS_KEY;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RedisUserChatSaver {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public void subscribeToUserChatUpdates(Long userId) {
+        try {
+            String subscribersKey = USER_CHAT_SUBSCRIBERS_KEY + userId;
+
+            stringRedisTemplate.opsForSet().add(subscribersKey, userId.toString());
+            stringRedisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
+
+            log.info("사용자 채팅 업데이트 구독 시작 - userId: {}", userId);
+        } catch (Exception e) {
+            log.error("사용자 채팅 업데이트 구독 실패 - userId: {}", userId, e);
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈 🛠
<!-- 관련 이슈 번호를 적어주세요. -->
- closes #102 

## 작업 내용 ✏️
<!-- 작업 내용을 간단히 작성해주세요. -->
- [ ] 새로운 채팅방이 생겼을 때를 위해 채팅방 목록 구독/구독 해제 로직을 구현했습니다.
- [ ] 상대방에게 처음 채팅을 보내서 상대방이 채팅방에 들어올 때, 만약 상대방이 채팅방 목록을 보고 있다면 NEW_CHAT_ROOM_CREATED 메시지를 보냅니다.

## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점 등을 필요하다면 작성해주세요. -->
