### PR TITLE
Feat #125 채팅 메시지 제한 걸릴 시 채팅 티켓 개수 반환 로직 구현

### DIFF
--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/MessageService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/MessageService.java
@@ -9,15 +9,18 @@ import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.implem
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.implement.MessageSaver;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.implement.MessageValidator;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.message.persistence.entity.Message;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.application.dto.ChatTicketValidationResult;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.business.ChatRoomParticipantService;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.business.ChatTicketService;
 import com.lovesoongalarm.lovesoongalarm.domain.user.business.UserService;
 import com.lovesoongalarm.lovesoongalarm.domain.user.persistence.entity.User;
+import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.messaging.MessageSender;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.socket.WebSocketSession;
 
 import java.util.Comparator;
 import java.util.List;
@@ -31,6 +34,7 @@ public class MessageService {
     private final MessageRetriever messageRetriever;
     private final MessageValidator messageValidator;
     private final MessageSaver messageSaver;
+    private final MessageSender messageSender;
 
     private final MessageConverter messageConverter;
 
@@ -124,9 +128,13 @@ public class MessageService {
     }
 
     @Transactional
-    public void sendMessage(ChatRoom chatRoom, String content, Long senderId) {
+    public void sendMessage(WebSocketSession session, ChatRoom chatRoom, String content, Long senderId) {
         log.info("1:1 채팅 메시지 전송 시작 - chatRoomId: {}, senderId: {}", chatRoom.getId(), senderId);
-        chatTicketService.validateAndProcessMessage(senderId, chatRoom.getId());
+        ChatTicketValidationResult validation = chatTicketService.validateMessageSending(senderId, chatRoom.getId());
+        if (!validation.canSend()) {
+            messageSender.sendMessageCountLimitWithTicketInfo(session, validation);
+            return;
+        }
         messageValidator.validateMessage(content);
 
         User sender = userService.findUserOrElseThrow(senderId);

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/application/dto/ChatTicketValidationResult.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/application/dto/ChatTicketValidationResult.java
@@ -2,20 +2,16 @@ package com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.a
 
 public record ChatTicketValidationResult(
         boolean canSend,
-        Integer remainingFreeMessages,
-        Integer availableTickets,
-        String reason
+        Integer availableTickets
 ) {
     public static ChatTicketValidationResult success() {
-        return new ChatTicketValidationResult(true, null, null, null);
+        return new ChatTicketValidationResult(true, null);
     }
 
     public static ChatTicketValidationResult limitExceeded(int availableTickets, int limit) {
         return new ChatTicketValidationResult(
                 false,
-                0,
-                availableTickets,
-                String.format("무료 메시지 %d개 모두 사용했습니다", limit)
+                availableTickets
         );
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/application/dto/ChatTicketValidationResult.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/application/dto/ChatTicketValidationResult.java
@@ -1,0 +1,21 @@
+package com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.application.dto;
+
+public record ChatTicketValidationResult(
+        boolean canSend,
+        Integer remainingFreeMessages,
+        Integer availableTickets,
+        String reason
+) {
+    public static ChatTicketValidationResult success() {
+        return new ChatTicketValidationResult(true, null, null, null);
+    }
+
+    public static ChatTicketValidationResult limitExceeded(int availableTickets, int limit) {
+        return new ChatTicketValidationResult(
+                false,
+                0,
+                availableTickets,
+                String.format("무료 메시지 %d개 모두 사용했습니다", limit)
+        );
+    }
+}

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/business/ChatTicketService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/business/ChatTicketService.java
@@ -1,17 +1,13 @@
 package com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.business;
 
-import com.lovesoongalarm.lovesoongalarm.common.exception.CustomException;
-import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.messaging.MessageSender;
-import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.exception.ChatRoomParticipantErrorCode;
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.application.dto.ChatTicketValidationResult;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.implement.ChatRoomParticipantRetriever;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.implement.ChatRoomParticipantUpdater;
 import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.persistence.entity.ChatRoomParticipant;
-import com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.session.SessionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.socket.WebSocketSession;
 
 @Service
 @Slf4j
@@ -21,28 +17,23 @@ public class ChatTicketService {
     private final ChatRoomParticipantRetriever chatRoomParticipantRetriever;
     private final ChatRoomParticipantUpdater chatRoomParticipantUpdater;
 
-    private final MessageSender messageSender;
-    private final SessionService sessionService;
-
     private static final int FREE_MESSAGE_LIMIT = 10;
 
     @Transactional
-    public void validateAndProcessMessage(Long userId, Long chatRoomId) {
+    public ChatTicketValidationResult validateMessageSending(Long userId, Long chatRoomId) {
         ChatRoomParticipant participant = chatRoomParticipantRetriever
                 .findByUserIdAndChatRoomId(userId, chatRoomId);
 
-        if (participant.hasUnlimitedChat()) return;
-
-        WebSocketSession session = sessionService.getSession(userId);
-        if (session == null || !session.isOpen()) {
-            log.debug("사용자 세션이 없거나 닫혀있음 - userId: {}", userId);
-            return;
+        if (participant.hasUnlimitedChat()) {
+            return ChatTicketValidationResult.success();
         }
 
         if (participant.getFreeMessageCount() >= FREE_MESSAGE_LIMIT) {
-            messageSender.sendMessageCountLimit(session);
-            throw new CustomException(ChatRoomParticipantErrorCode.EXCEED_MESSAGE_LIMIT);
+            int remainingTickets = participant.getTicketCount();
+            return ChatTicketValidationResult.limitExceeded(remainingTickets, FREE_MESSAGE_LIMIT);
         }
+
         chatRoomParticipantUpdater.incrementFreeMessageCount(participant.getId());
+        return ChatTicketValidationResult.success();
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/persistence/entity/ChatRoomParticipant.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/participant/persistence/entity/ChatRoomParticipant.java
@@ -66,4 +66,8 @@ public class ChatRoomParticipant {
     public void setTicketUsed() {
         this.ticketUsed = true;
     }
+
+    public int getTicketCount() {
+        return this.getUser().getChatTicket();
+    }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/business/ChatService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/business/ChatService.java
@@ -44,11 +44,11 @@ public class ChatService {
     }
 
     @Transactional
-    public void handleSendMessage(Long chatRoomId, String content, Long userId) {
+    public void handleSendMessage(WebSocketSession session, Long chatRoomId, String content, Long userId) {
         log.info("메시지 송신 시작 - userId: {}, chatRoomId: {}", userId, chatRoomId);
         chatRoomService.validateChatRoomAccess(userId, chatRoomId);
         ChatRoom chatRoom = chatRoomService.getChatRoomOrElseThrow(chatRoomId);
-        messageService.sendMessage(chatRoom, content, userId);
+        messageService.sendMessage(session, chatRoom, content, userId);
         log.info("메시지 송신 완료 - userId: {}, chatRoomId: {}", userId, chatRoomId);
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/business/WebSocketMessageRouter.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/business/WebSocketMessageRouter.java
@@ -100,7 +100,7 @@ public class WebSocketMessageRouter {
 
     private void handleSendMessage(WebSocketSession session, WebSocketMessageDTO.Request request, Long userId) {
         try {
-            chatService.handleSendMessage(request.chatRoomId(), request.content(), userId);
+            chatService.handleSendMessage(session, request.chatRoomId(), request.content(), userId);
         } catch (CustomException e) {
             log.warn("메시지 전송 실패 - 채팅방: {}, 유저: {}, 이유: {}", request.chatRoomId(), userId, e.getErrorCode().getMessage());
             messageSender.sendErrorMessage(session, e.getErrorCode().getStatus().toString(), e.getErrorCode().getMessage());

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/dto/WebSocketMessageDTO.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/dto/WebSocketMessageDTO.java
@@ -89,7 +89,9 @@ public class WebSocketMessageDTO {
 
     @Builder
     public record MessageCountLimit(
-            EWebSocketMessageType type
+            EWebSocketMessageType type,
+            boolean canSend,
+            Integer availableTickets
     ) {
     }
 

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/MessageSender.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/websocket/sub/messaging/MessageSender.java
@@ -1,5 +1,6 @@
 package com.lovesoongalarm.lovesoongalarm.domain.websocket.sub.messaging;
 
+import com.lovesoongalarm.lovesoongalarm.domain.chat.sub.room.sub.participant.application.dto.ChatTicketValidationResult;
 import com.lovesoongalarm.lovesoongalarm.domain.notification.application.dto.NotificationWebSocketDTO;
 import com.lovesoongalarm.lovesoongalarm.domain.notification.persistence.type.EWebSocketNotificationType;
 import com.lovesoongalarm.lovesoongalarm.domain.websocket.dto.WebSocketMessageDTO;
@@ -144,14 +145,6 @@ public class MessageSender {
         messageTransmitter.sendMessage(session, chatListUpdate);
     }
 
-    public void sendMessageCountLimit(WebSocketSession session){
-        WebSocketMessageDTO.MessageCountLimit messageCountLimit = WebSocketMessageDTO.MessageCountLimit.builder()
-                .type(EWebSocketMessageType.MESSAGE_COUNT_LIMIT)
-                .build();
-
-        messageTransmitter.sendMessage(session, messageCountLimit);
-    }
-
     public void sendNotification(WebSocketSession session, NotificationWebSocketDTO.Notification notification) {
         messageTransmitter.sendMessage(session, notification);
     }
@@ -199,5 +192,15 @@ public class MessageSender {
                 .build();
 
         messageTransmitter.sendMessage(session, allChangeNotification);
+    }
+
+    public void sendMessageCountLimitWithTicketInfo(WebSocketSession session, ChatTicketValidationResult validation) {
+        WebSocketMessageDTO.MessageCountLimit messageCountLimit = WebSocketMessageDTO.MessageCountLimit.builder()
+                .type(EWebSocketMessageType.MESSAGE_COUNT_LIMIT)
+                .canSend(validation.canSend())
+                .availableTickets(validation.availableTickets())
+                .build();
+
+        messageTransmitter.sendMessage(session, messageCountLimit);
     }
 }


### PR DESCRIPTION
## 관련 이슈 🛠
<!-- 관련 이슈 번호를 적어주세요. -->
- closes #125 

## 작업 내용 ✏️
<!-- 작업 내용을 간단히 작성해주세요. -->
- [ ] 채팅 메시지 전송 시 제한이 걸리면 에러 대신 메시지를 반환하도록 하고, 거기에 남은 티켓 수를 반환하도록 구현했습니다.

## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점 등을 필요하다면 작성해주세요. -->
