### PR TITLE
Fix #175 LEFT 조인으로 관심사가 없는 회원도 조회하도록 변경

### DIFF
--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/repository/UserRepository.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/user/persistence/repository/UserRepository.java
@@ -23,7 +23,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("""
             SELECT DISTINCT u FROM User u
-            JOIN FETCH u.interests i
+            LEFT JOIN FETCH u.interests i
             WHERE u.id = (
                 SELECT cp.user.id 
                 FROM ChatRoomParticipant cp 


### PR DESCRIPTION
## 관련 이슈 🛠
<!-- 관련 이슈 번호를 적어주세요. -->
- closes #175 

## 작업 내용 ✏️
<!-- 작업 내용을 간단히 작성해주세요. -->
- [ ] 기존의 로직은 단순히 interests와 조인하므로 회원탈퇴한 상대방을 조회하지 못합니다. 이를 LEFT 조인으로 해결합니다.

## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점 등을 필요하다면 작성해주세요. -->
