### PR TITLE
Refactor #233 메시지 배치 업데이트 처리 시 != 조건 대신 = 조건을 사용하도록 변경

### DIFF
--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/MessageReadService.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/business/MessageReadService.java
@@ -21,13 +21,13 @@ public class MessageReadService {
         log.info("미읽은 메시지 일괄 읽음 처리 시작 - chatRoomId: {}, userId: {}", chatRoomId, userId);
 
         try {
-            int updatedCount = messageUpdater.markMessagesAsReadByChatRoomAndReceiver(chatRoomId, userId);
+            User partner = userService.getPartnerUser(chatRoomId, userId);
+
+            int updatedCount = messageUpdater.markMessagesAsReadByChatRoomAndReceiver(chatRoomId, partner.getId());
             if (updatedCount == 0) {
                 log.info("읽음 처리할 메시지가 없음 - chatRoomId: {}, userId: {}", chatRoomId, userId);
                 return ReadResult.empty();
             }
-
-            User partner = userService.getPartnerUser(chatRoomId, userId);
 
             log.info("미읽은 메시지 일괄 읽음 처리 완료 - updatedCount: {}, partnerId: {}",
                     updatedCount, partner.getId());

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/implement/MessageUpdater.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/implement/MessageUpdater.java
@@ -21,10 +21,10 @@ public class MessageUpdater {
     }
 
     @Transactional
-    public int markMessagesAsReadByChatRoomAndReceiver(Long chatRoomId, Long receiverId) {
-        int updatedCount = messageRepository.markUnreadMessagesAsRead(chatRoomId, receiverId);
-        log.info("채팅방 미읽은 메시지 일괄 읽음 처리 완료 - chatRoomId: {}, receiverId: {}, updatedCount: {}",
-                chatRoomId, receiverId, updatedCount);
+    public int markMessagesAsReadByChatRoomAndReceiver(Long chatRoomId, Long partnerId) {
+        int updatedCount = messageRepository.markUnreadMessagesAsRead(chatRoomId, partnerId);
+        log.info("채팅방 미읽은 메시지 일괄 읽음 처리 완료 - chatRoomId: {}, partnerId: {}, updatedCount: {}",
+                chatRoomId, partnerId, updatedCount);
         return updatedCount;
     }
 }

--- a/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/persistence/repository/MessageRepository.java
+++ b/src/main/java/com/lovesoongalarm/lovesoongalarm/domain/chat/sub/room/sub/message/persistence/repository/MessageRepository.java
@@ -70,12 +70,12 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
             UPDATE Message m 
             SET m.isRead = true 
             WHERE m.chatRoom.id = :chatRoomId 
-            AND m.user.id != :receiverId 
+            AND m.user.id = :partnerId
             AND m.isRead = false
             """)
     int markUnreadMessagesAsRead(
             @Param("chatRoomId") Long chatRoomId,
-            @Param("receiverId") Long receiverId
+            @Param("partnerId") Long partnerId
     );
 
     @Query("""


### PR DESCRIPTION
## 관련 이슈 🛠
<!-- 관련 이슈 번호를 적어주세요. -->
- closes #233 

## 작업 내용 ✏️
<!-- 작업 내용을 간단히 작성해주세요. -->
- [ ] 구독 시 내 userId가 아닌 메시지를 읽음 처리 하는 대신 상대방의 userId와 동일한 메시지들을 읽음 처리하도록 변경합니다.

## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점 등을 필요하다면 작성해주세요. -->
